### PR TITLE
feat: Add Shortcut integration for task sync

### DIFF
--- a/docs/src/pages/cli.astro
+++ b/docs/src/pages/cli.astro
@@ -196,23 +196,58 @@ dex plan feature.md --parent abc123`}
     </Terminal>
   </div>
 
-  <h2>GitHub</h2>
+  <h2>Integrations</h2>
 
   <div class="command-card">
     <h3>dex sync</h3>
-    <div class="synopsis">dex sync [options]</div>
-    <p>Sync tasks to GitHub Issues. Requires <code>[sync.github]</code> configuration in <code>dex.toml</code>.</p>
+    <div class="synopsis">dex sync [task-id] [options]</div>
+    <p>Sync tasks to GitHub Issues and/or Shortcut Stories. Syncs all root tasks by default, or a specific task if ID is provided.</p>
+    <ul>
+      <li><code>--github</code> — Sync only to GitHub Issues</li>
+      <li><code>--shortcut</code> — Sync only to Shortcut Stories</li>
+      <li><code>--dry-run</code> — Preview what would be synced without making changes</li>
+    </ul>
     <Terminal title="Terminal">
-      <Code code="dex sync" lang="bash" theme="vitesse-black" />
+      <Code
+        code={`dex sync                    # Sync to all configured services
+dex sync abc123             # Sync specific task
+dex sync --github           # Sync only to GitHub
+dex sync --shortcut         # Sync only to Shortcut
+dex sync --dry-run          # Preview sync`}
+        lang="bash"
+        theme="vitesse-black"
+      />
     </Terminal>
   </div>
 
   <div class="command-card">
     <h3>dex import</h3>
-    <div class="synopsis">dex import &lt;github-issue-url&gt;</div>
-    <p>Import a GitHub Issue as a dex task.</p>
+    <div class="synopsis">dex import &lt;ref&gt; [options]</div>
+    <p>Import a GitHub Issue or Shortcut Story as a dex task.</p>
+    <ul>
+      <li><code>--all</code> — Import all items with the dex label</li>
+      <li><code>--github</code> — Filter <code>--all</code> to only GitHub</li>
+      <li><code>--shortcut</code> — Filter <code>--all</code> to only Shortcut</li>
+      <li><code>--update</code> — Update existing task if already imported</li>
+      <li><code>--dry-run</code> — Preview what would be imported</li>
+    </ul>
+    <p><strong>Reference formats:</strong></p>
+    <ul>
+      <li>GitHub: <code>#123</code>, <code>owner/repo#123</code>, or full URL</li>
+      <li>Shortcut: <code>sc#123</code>, <code>SC#123</code>, or full URL</li>
+    </ul>
     <Terminal title="Terminal">
-      <Code code="dex import https://github.com/owner/repo/issues/123" lang="bash" theme="vitesse-black" />
+      <Code
+        code={`dex import #42                    # Import GitHub issue #42
+dex import sc#123                 # Import Shortcut story #123
+dex import https://github.com/owner/repo/issues/42
+dex import https://app.shortcut.com/myorg/story/123
+dex import --all                  # Import all dex-labeled items
+dex import --all --shortcut       # Import only from Shortcut
+dex import #42 --update           # Refresh local task from GitHub`}
+        lang="bash"
+        theme="vitesse-black"
+      />
     </Terminal>
   </div>
 
@@ -319,6 +354,12 @@ ls $(dex dir)          # List task directory contents`}
       <li><code>sync.github.label_prefix</code> — Label prefix for dex tasks</li>
       <li><code>sync.github.auto.on_change</code> — Sync on mutations (boolean)</li>
       <li><code>sync.github.auto.max_age</code> — Max age before stale (e.g., 30m, 1h)</li>
+      <li><code>sync.shortcut.enabled</code> — Enable Shortcut sync (boolean)</li>
+      <li><code>sync.shortcut.token_env</code> — Environment variable for Shortcut token</li>
+      <li><code>sync.shortcut.workspace</code> — Shortcut workspace slug (auto-detected if not set)</li>
+      <li><code>sync.shortcut.team</code> — Team ID or mention name (required for sync)</li>
+      <li><code>sync.shortcut.workflow</code> — Workflow ID (uses team default if not set)</li>
+      <li><code>sync.shortcut.label</code> — Label name for dex stories (default: "dex")</li>
     </ul>
     <Terminal title="Terminal">
       <Code
@@ -395,6 +436,10 @@ dex help complete`}
       <tr>
         <td><code>GITHUB_TOKEN</code></td>
         <td>GitHub API token for sync/import</td>
+      </tr>
+      <tr>
+        <td><code>SHORTCUT_API_TOKEN</code></td>
+        <td>Shortcut API token for sync/import</td>
       </tr>
     </tbody>
   </table>

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.0.0",
     "@octokit/rest": "^22.0.1",
+    "@shortcut/client": "^3.1.0",
     "nanoid": "^5.0.0",
     "smol-toml": "^1.6.0",
     "zod": "^3.23.0"

--- a/plugins/dex/skills/dex/SKILL.md
+++ b/plugins/dex/skills/dex/SKILL.md
@@ -17,8 +17,8 @@ command -v dex &>/dev/null && echo "use: dex" || echo "use: npx @zeeg/dex"
 
 Dex tasks are **tickets** - structured artifacts with comprehensive context:
 
-- **Description**: One-line summary (issue title)
-- **Context**: Full background, requirements, approach (issue body)
+- **Name**: One-line summary (issue title)
+- **Description**: Full background, requirements, approach (issue body)
 - **Result**: Implementation details, decisions, outcomes (PR description)
 
 Think: "Would someone understand the what, why, and how from this task alone?"
@@ -57,10 +57,10 @@ Use **dex** for persistent work. Use **TaskCreate** for ephemeral in-session tra
 ### Create a Task
 
 ```bash
-dex create -d "Short description" --context "Full implementation context"
+dex create "Short name" --description "Full implementation context"
 ```
 
-Context should include: what needs to be done, why, implementation approach, and acceptance criteria. See [examples.md](examples.md) for good/bad examples.
+Description should include: what needs to be done, why, implementation approach, and acceptance criteria. See [examples.md](examples.md) for good/bad examples.
 
 ### List and View Tasks
 
@@ -81,20 +81,20 @@ dex complete <id> --result "What was accomplished" --commit <sha>
 ### Edit and Delete
 
 ```bash
-dex edit <id> --context "Updated context"
+dex edit <id> --description "Updated description"
 dex delete <id>
 ```
 
 For full CLI reference including blockers, see [cli-reference.md](cli-reference.md).
 
-## Understanding Task Context
+## Understanding Task Fields
 
 Tasks have two text fields:
 
-- **Description**: Brief one-line summary (shown in `dex list`)
-- **Context**: Full details - requirements, approach, acceptance criteria (shown with `--full`)
+- **Name**: Brief one-line summary (shown in `dex list`)
+- **Description**: Full details - requirements, approach, acceptance criteria (shown with `--full`)
 
-When you run `dex show <id>`, the context may be truncated. The CLI will hint at `--full` if there's more content.
+When you run `dex show <id>`, the description may be truncated. The CLI will hint at `--full` if there's more content.
 
 ### Gathering Context
 
@@ -136,7 +136,7 @@ Three levels: **Epic** (large initiative) → **Task** (significant work) → **
 
 ```bash
 # Create subtask under parent
-dex create --parent <id> -d "Description" --context "..."
+dex create --parent <id> "Subtask name" --description "..."
 ```
 
 For detailed hierarchy guidance, see [hierarchies.md](hierarchies.md).
@@ -166,7 +166,7 @@ Check `dex show <id>` for GitHub issue info before committing. The "(via parent)
 ## Best Practices
 
 1. **Right-size tasks**: Completable in one focused session
-2. **Clear completion criteria**: Context should define "done"
+2. **Clear completion criteria**: Description should define "done"
 3. **Don't over-decompose**: 3-7 children per parent
 4. **Action-oriented descriptions**: Start with verbs ("Add", "Fix", "Update")
 5. **Verify before completing**: Tests passing, manual testing done

--- a/plugins/dex/skills/dex/cli-reference.md
+++ b/plugins/dex/skills/dex/cli-reference.md
@@ -5,13 +5,13 @@ Full command reference for dex. For basic usage, see SKILL.md.
 ## Create a Task
 
 ```bash
-dex create -d "Short description" --context "Full implementation context"
+dex create "Task name" --description "Full implementation details"
 ```
 
 Options:
 
-- `-d, --description` (required): One-line summary
-- `--context` (required): Full implementation details
+- `<name>` or `-n, --name`: One-line summary (required)
+- `-d, --description`: Full implementation details (optional but recommended)
 - `-p, --priority <n>`: Lower = higher priority (default: 1)
 - `-b, --blocked-by <ids>`: Comma-separated task IDs that must complete first
 - `--parent <id>`: Parent task ID (creates subtask)
@@ -24,7 +24,7 @@ dex list --all                # Include completed
 dex list --completed          # Only completed
 dex list --ready              # Only tasks ready to work on (no blockers)
 dex list --blocked            # Only blocked tasks
-dex list --query "login"      # Search in description/context
+dex list --query "login"      # Search in name/description
 ```
 
 Blocked tasks show an indicator: `[B: xyz123]` (blocked by task xyz123) or `[B: 2]` (blocked by 2 tasks).
@@ -56,7 +56,7 @@ This captures commit SHA, message, and branch automatically.
 ## Edit a Task
 
 ```bash
-dex edit <id> -d "Updated description" --context "Updated context"
+dex edit <id> -n "Updated name" --description "Updated description"
 dex edit <id> --add-blocker xyz123      # Add blocking dependency
 dex edit <id> --remove-blocker xyz123   # Remove blocking dependency
 ```
@@ -75,7 +75,7 @@ Use blocking dependencies to enforce task ordering:
 
 ```bash
 # Create a task that depends on another
-dex create -d "Deploy to production" --context "..." --blocked-by abc123
+dex create "Deploy to production" --description "..." --blocked-by abc123
 
 # Add a blocker to an existing task
 dex edit xyz789 --add-blocker abc123
@@ -121,14 +121,12 @@ Override with `--storage-path` or `DEX_STORAGE_PATH` env var.
 {
   "id": "abc123",
   "parent_id": null,
-  "description": "One-line summary",
-  "context": "Full implementation details...",
+  "name": "One-line summary",
+  "description": "Full implementation details...",
   "priority": 1,
   "completed": false,
   "result": null,
-  "blockedBy": ["xyz789"],
-  "blocks": ["def456"],
-  "children": [],
+  "blocked_by": ["xyz789"],
   "created_at": "2026-01-01T00:00:00.000Z",
   "updated_at": "2026-01-01T00:00:00.000Z",
   "completed_at": null

--- a/plugins/dex/skills/dex/examples.md
+++ b/plugins/dex/skills/dex/examples.md
@@ -1,19 +1,20 @@
 # Examples
 
-Good and bad examples for writing task context and results.
+Good and bad examples for writing task descriptions and results.
 
-## Writing Context
+## Writing Descriptions
 
-Context should include everything needed to do the work without asking questions:
+Descriptions should include everything needed to do the work without asking questions:
+
 - **What** needs to be done and why
 - **Implementation approach** (steps, files to modify, technical choices)
 - **Done when** (acceptance criteria)
 
-### Good Context Example
+### Good Description Example
 
 ```bash
-dex create -d "Migrate storage to one file per task" \
-  --context "Change storage format for git-friendliness:
+dex create "Migrate storage to one file per task" \
+  --description "Change storage format for git-friendliness:
 
 Structure:
 .dex/
@@ -46,10 +47,10 @@ Benefits:
 
 Notice: States the goal, shows the structure, lists specific implementation steps, and explains benefits. Someone could pick this up without asking questions.
 
-### Bad Context Example
+### Bad Description Example
 
 ```bash
-dex create -d "Add auth" --context "Need to add authentication"
+dex create "Add auth" --description "Need to add authentication"
 ```
 
 ❌ Missing: How to implement it, what files, what's done when, technical approach
@@ -57,6 +58,7 @@ dex create -d "Add auth" --context "Need to add authentication"
 ## Writing Results
 
 Results should capture what was actually done:
+
 - **What changed** (implementation summary)
 - **Key decisions** (and why)
 - **Verification** (tests passing, manual testing done)
@@ -95,7 +97,7 @@ dex complete abc123 --result "Fixed the storage issue"
 
 ❌ Missing: What was actually implemented, how, what decisions were made
 
-## Subtask Context Example
+## Subtask Description Example
 
 Link subtasks to their parent and explain what this piece does specifically:
 

--- a/plugins/dex/skills/dex/hierarchies.md
+++ b/plugins/dex/skills/dex/hierarchies.md
@@ -4,26 +4,29 @@ Guidance for organizing work into epics, tasks, and subtasks.
 
 ## Three Levels
 
-| Level | Name | Purpose | Example |
-|-------|------|---------|---------|
-| L0 | **Epic** | Large initiative (5+ tasks) | "Add user authentication system" |
-| L1 | **Task** | Significant work item | "Implement JWT middleware" |
-| L2 | **Subtask** | Atomic implementation step | "Add token verification function" |
+| Level | Name        | Purpose                     | Example                           |
+| ----- | ----------- | --------------------------- | --------------------------------- |
+| L0    | **Epic**    | Large initiative (5+ tasks) | "Add user authentication system"  |
+| L1    | **Task**    | Significant work item       | "Implement JWT middleware"        |
+| L2    | **Subtask** | Atomic implementation step  | "Add token verification function" |
 
 **Maximum depth is 3 levels.** Attempting to create a child of a subtask will fail.
 
 ## When to Use Each Level
 
 ### Single Task (No Hierarchy)
+
 - Small feature (1-2 files, ~1 session)
 - Work is atomic, no natural breakdown
 
 ### Task with Subtasks
+
 - Medium feature (3-5 files, 3-7 steps)
 - Work naturally decomposes into discrete steps
 - Subtasks could be worked on independently
 
 ### Epic with Tasks
+
 - Large initiative (multiple areas, many sessions)
 - Work spans 5+ distinct tasks
 - You want high-level progress tracking
@@ -32,24 +35,25 @@ Guidance for organizing work into epics, tasks, and subtasks.
 
 ```bash
 # Create the epic
-dex create -d "Add user authentication system" \
-  --context "Full auth system with JWT tokens, password reset..."
+dex create "Add user authentication system" \
+  --description "Full auth system with JWT tokens, password reset..."
 
 # Create tasks under it (note the epic ID, e.g., abc123)
-dex create --parent abc123 -d "Implement JWT token generation" \
-  --context "Create token service with signing and verification..."
+dex create --parent abc123 "Implement JWT token generation" \
+  --description "Create token service with signing and verification..."
 
-dex create --parent abc123 -d "Add password reset flow" \
-  --context "Email-based password reset with secure tokens..."
+dex create --parent abc123 "Add password reset flow" \
+  --description "Email-based password reset with secure tokens..."
 
 # For complex tasks, add subtasks
-dex create --parent def456 -d "Add token verification function" \
-  --context "Verify JWT signature and expiration..."
+dex create --parent def456 "Add token verification function" \
+  --description "Verify JWT signature and expiration..."
 ```
 
 ## Subtask Best Practices
 
 Each subtask should be:
+
 - **Independently understandable**: Clear on its own
 - **Linked to parent**: Reference parent, explain how this piece fits
 - **Specific scope**: What this subtask does vs what parent/siblings do

--- a/plugins/dex/skills/dex/verification.md
+++ b/plugins/dex/skills/dex/verification.md
@@ -4,7 +4,7 @@ Before marking any task complete, you MUST verify your work. Verification separa
 
 ## The Verification Process
 
-1. **Re-read the task context**: What did you originally commit to do?
+1. **Re-read the task description**: What did you originally commit to do?
 2. **Check acceptance criteria**: Does your implementation satisfy the "Done when" conditions?
 3. **Run relevant tests**: Execute the test suite and document results
 4. **Test manually**: Actually try the feature/change yourself
@@ -13,11 +13,13 @@ Before marking any task complete, you MUST verify your work. Verification separa
 ## Strong vs Weak Verification
 
 ### Strong Verification Examples
+
 - ✅ "All 60 tests passing, build successful"
 - ✅ "All 69 tests passing (4 new tests for middleware edge cases)"
 - ✅ "Manually tested with valid/invalid/expired tokens - all cases work"
 
 ### Weak Verification (Avoid)
+
 - ❌ "Should work now" — "should" means not verified
 - ❌ "Made the changes" — no evidence it works
 - ❌ "Added tests" — did the tests pass? What's the count?
@@ -25,20 +27,20 @@ Before marking any task complete, you MUST verify your work. Verification separa
 
 ## Verification by Task Type
 
-| Task Type | How to Verify |
-|-----------|---------------|
-| Code changes | Run full test suite, document passing count |
-| New features | Run tests + manual testing of functionality |
-| Configuration | Test the config works (run commands, check workflows) |
+| Task Type     | How to Verify                                           |
+| ------------- | ------------------------------------------------------- |
+| Code changes  | Run full test suite, document passing count             |
+| New features  | Run tests + manual testing of functionality             |
+| Configuration | Test the config works (run commands, check workflows)   |
 | Documentation | Verify examples work, links resolve, formatting renders |
-| Refactoring | Confirm tests still pass, no behavior changes |
+| Refactoring   | Confirm tests still pass, no behavior changes           |
 
 ## Cross-Reference Checklist
 
 Before marking complete, verify all applicable items:
 
-- [ ] Task description requirements met
-- [ ] Context "Done when" criteria satisfied
+- [ ] Task name requirements met
+- [ ] Description "Done when" criteria satisfied
 - [ ] Tests passing (document count: "All X tests passing")
 - [ ] Build succeeds (if applicable)
 - [ ] Manual testing done (describe what you tested)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,6 +14,9 @@ importers:
       '@octokit/rest':
         specifier: ^22.0.1
         version: 22.0.1
+      '@shortcut/client':
+        specifier: ^3.1.0
+        version: 3.1.0
       nanoid:
         specifier: ^5.0.0
         version: 5.1.6
@@ -444,6 +447,9 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@shortcut/client@3.1.0':
+    resolution: {integrity: sha512-+ywXLviDhMvfei5Gk7kvKPEYoC6sCrsFIXUbd6Bp+TYC7QbkK94XlxyFj33jMkGp6zuq6Rb8SaTnRN5xEIC5cQ==}
+
   '@standard-schema/spec@1.1.0':
     resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
 
@@ -531,6 +537,12 @@ packages:
   ast-v8-to-istanbul@0.3.10:
     resolution: {integrity: sha512-p4K7vMz2ZSk3wN8l5o3y2bJAoZXT3VuJI5OLTATY/01CYWumWvwkUw0SqDBnNq6IiTO3qDa1eSQDibAV8g7XOQ==}
 
+  asynckit@0.4.0:
+    resolution: {integrity: sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==}
+
+  axios@1.13.3:
+    resolution: {integrity: sha512-ERT8kdX7DZjtUm7IitEyV7InTHAF42iJuMArIiDIV5YtPanJkgw4hw5Dyg9fh0mihdWNn1GKaeIWErfe56UQ1g==}
+
   before-after-hook@4.0.0:
     resolution: {integrity: sha512-q6tR3RPqIB1pMiTRMFcZwuG5T8vwp+vUvEG0vuI6B+Rikh5BfPp2fQ82c925FOs+b0lcFQ8CFrL+KbilfZFhOQ==}
 
@@ -569,6 +581,10 @@ packages:
   colorette@2.0.20:
     resolution: {integrity: sha512-IfEDxwoWIjkeXL1eXcDiow4UbKjhLdq6/EuSVR9GMN7KVH3r9gQ83e73hsz1Nd1T3ijd5xv1wcWRYO+D6kCI2w==}
 
+  combined-stream@1.0.8:
+    resolution: {integrity: sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==}
+    engines: {node: '>= 0.8'}
+
   commander@14.0.2:
     resolution: {integrity: sha512-TywoWNNRbhoD0BXs1P3ZEScW8W5iKrnbithIl0YH+uCmBd0QpPOA8yc82DS3BIE5Ma6FnBVUsJ7wVUDz4dvOWQ==}
     engines: {node: '>=20'}
@@ -606,6 +622,10 @@ packages:
       supports-color:
         optional: true
 
+  delayed-stream@1.0.0:
+    resolution: {integrity: sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==}
+    engines: {node: '>=0.4.0'}
+
   depd@2.0.0:
     resolution: {integrity: sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==}
     engines: {node: '>= 0.8'}
@@ -641,6 +661,10 @@ packages:
 
   es-object-atoms@1.1.1:
     resolution: {integrity: sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==}
+    engines: {node: '>= 0.4'}
+
+  es-set-tostringtag@2.1.0:
+    resolution: {integrity: sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==}
     engines: {node: '>= 0.4'}
 
   esbuild@0.27.2:
@@ -709,6 +733,19 @@ packages:
     resolution: {integrity: sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==}
     engines: {node: '>= 18.0.0'}
 
+  follow-redirects@1.15.11:
+    resolution: {integrity: sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ==}
+    engines: {node: '>=4.0'}
+    peerDependencies:
+      debug: '*'
+    peerDependenciesMeta:
+      debug:
+        optional: true
+
+  form-data@4.0.5:
+    resolution: {integrity: sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==}
+    engines: {node: '>= 6'}
+
   forwarded@0.2.0:
     resolution: {integrity: sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==}
     engines: {node: '>= 0.6'}
@@ -747,6 +784,10 @@ packages:
 
   has-symbols@1.1.0:
     resolution: {integrity: sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==}
+    engines: {node: '>= 0.4'}
+
+  has-tostringtag@1.0.2:
+    resolution: {integrity: sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==}
     engines: {node: '>= 0.4'}
 
   hasown@2.0.2:
@@ -858,8 +899,16 @@ packages:
     resolution: {integrity: sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==}
     engines: {node: '>=8.6'}
 
+  mime-db@1.52.0:
+    resolution: {integrity: sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==}
+    engines: {node: '>= 0.6'}
+
   mime-db@1.54.0:
     resolution: {integrity: sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==}
+    engines: {node: '>= 0.6'}
+
+  mime-types@2.1.35:
+    resolution: {integrity: sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==}
     engines: {node: '>= 0.6'}
 
   mime-types@3.0.2:
@@ -970,6 +1019,9 @@ packages:
   proxy-addr@2.0.7:
     resolution: {integrity: sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==}
     engines: {node: '>= 0.10'}
+
+  proxy-from-env@1.1.0:
+    resolution: {integrity: sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==}
 
   qs@6.14.1:
     resolution: {integrity: sha512-4EK3+xJl8Ts67nLYNwqw/dsFVnCf+qR7RgXSK9jEEm9unao3njwMDdmsdvoKBKHzxd7tCYz5e5M+SnMjdtXGQQ==}
@@ -1537,6 +1589,12 @@ snapshots:
   '@rollup/rollup-win32-x64-msvc@4.56.0':
     optional: true
 
+  '@shortcut/client@3.1.0':
+    dependencies:
+      axios: 1.13.3
+    transitivePeerDependencies:
+      - debug
+
   '@standard-schema/spec@1.1.0': {}
 
   '@types/chai@5.2.3':
@@ -1637,6 +1695,16 @@ snapshots:
       estree-walker: 3.0.3
       js-tokens: 9.0.1
 
+  asynckit@0.4.0: {}
+
+  axios@1.13.3:
+    dependencies:
+      follow-redirects: 1.15.11
+      form-data: 4.0.5
+      proxy-from-env: 1.1.0
+    transitivePeerDependencies:
+      - debug
+
   before-after-hook@4.0.0: {}
 
   body-parser@2.2.2:
@@ -1682,6 +1750,10 @@ snapshots:
 
   colorette@2.0.20: {}
 
+  combined-stream@1.0.8:
+    dependencies:
+      delayed-stream: 1.0.0
+
   commander@14.0.2: {}
 
   content-disposition@1.0.1: {}
@@ -1706,6 +1778,8 @@ snapshots:
   debug@4.4.3:
     dependencies:
       ms: 2.1.3
+
+  delayed-stream@1.0.0: {}
 
   depd@2.0.0: {}
 
@@ -1732,6 +1806,13 @@ snapshots:
   es-object-atoms@1.1.1:
     dependencies:
       es-errors: 1.3.0
+
+  es-set-tostringtag@2.1.0:
+    dependencies:
+      es-errors: 1.3.0
+      get-intrinsic: 1.3.0
+      has-tostringtag: 1.0.2
+      hasown: 2.0.2
 
   esbuild@0.27.2:
     optionalDependencies:
@@ -1842,6 +1923,16 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  follow-redirects@1.15.11: {}
+
+  form-data@4.0.5:
+    dependencies:
+      asynckit: 0.4.0
+      combined-stream: 1.0.8
+      es-set-tostringtag: 2.1.0
+      hasown: 2.0.2
+      mime-types: 2.1.35
+
   forwarded@0.2.0: {}
 
   fresh@2.0.0: {}
@@ -1876,6 +1967,10 @@ snapshots:
   has-flag@4.0.0: {}
 
   has-symbols@1.1.0: {}
+
+  has-tostringtag@1.0.2:
+    dependencies:
+      has-symbols: 1.1.0
 
   hasown@2.0.2:
     dependencies:
@@ -1988,7 +2083,13 @@ snapshots:
       braces: 3.0.3
       picomatch: 2.3.1
 
+  mime-db@1.52.0: {}
+
   mime-db@1.54.0: {}
+
+  mime-types@2.1.35:
+    dependencies:
+      mime-db: 1.52.0
 
   mime-types@3.0.2:
     dependencies:
@@ -2064,6 +2165,8 @@ snapshots:
     dependencies:
       forwarded: 0.2.0
       ipaddr.js: 1.9.1
+
+  proxy-from-env@1.1.0: {}
 
   qs@6.14.1:
     dependencies:

--- a/src/cli/help.ts
+++ b/src/cli/help.ts
@@ -38,8 +38,12 @@ ${colors.bold}COMMANDS:${colors.reset}
   archive --older-than 60d         Archive tasks completed >60 days ago
   archive --completed              Archive ALL completed tasks
   plan <file>                      Create task from plan markdown file
-  sync [id]                        Push tasks to GitHub Issues
-  import <ref>                     Import GitHub Issue as task
+  sync [id]                        Push tasks to GitHub/Shortcut
+  sync --github                    Sync only to GitHub Issues
+  sync --shortcut                  Sync only to Shortcut Stories
+  import #N                        Import GitHub issue
+  import sc#N                      Import Shortcut story
+  import --all                     Import all dex-labeled items
   export <id>...                   Export tasks to GitHub (no sync back)
   completion <shell>               Generate shell completion script
 
@@ -79,5 +83,17 @@ ${colors.bold}EXAMPLES:${colors.reset}
   ${colors.dim}# Other common operations:${colors.reset}
   dex list --json | jq '.[] | .id'
   dex create "Subtask" --description "..." --parent abc123
+
+  ${colors.dim}# Sync tasks to external services:${colors.reset}
+  dex sync                          # Sync to all configured services
+  dex sync --github                 # Sync only to GitHub
+  dex sync --shortcut               # Sync only to Shortcut
+  dex sync --dry-run                # Preview what would be synced
+
+  ${colors.dim}# Import from external services:${colors.reset}
+  dex import #42                    # Import GitHub issue #42
+  dex import sc#123                 # Import Shortcut story #123
+  dex import --all                  # Import all dex-labeled items
+  dex import --all --shortcut       # Import only from Shortcut
 `);
 }

--- a/src/cli/import.ts
+++ b/src/cli/import.ts
@@ -11,8 +11,15 @@ import {
   parseRootTaskMetadata,
   getGitHubToken,
 } from "../core/github/index.js";
+import {
+  getShortcutStoryId,
+  getShortcutToken,
+  ShortcutApi,
+  parseTaskMetadata as parseShortcutTaskMetadata,
+  parseStoryDescription,
+} from "../core/shortcut/index.js";
 import { loadConfig } from "../core/config.js";
-import type { Task } from "../types.js";
+import type { Task, ShortcutMetadata } from "../types.js";
 import { Octokit } from "@octokit/rest";
 
 export async function importCommand(
@@ -25,58 +32,144 @@ export async function importCommand(
       all: { hasValue: false },
       "dry-run": { hasValue: false },
       update: { hasValue: false },
+      github: { hasValue: false },
+      shortcut: { hasValue: false },
       help: { short: "h", hasValue: false },
     },
     "import",
   );
 
   if (getBooleanFlag(flags, "help")) {
-    console.log(`${colors.bold}dex import${colors.reset} - Import GitHub Issues as tasks
+    console.log(`${colors.bold}dex import${colors.reset} - Import GitHub Issues or Shortcut Stories as tasks
 
 ${colors.bold}USAGE:${colors.reset}
-  dex import #123          # Import issue #123 from inferred repo
-  dex import <url>         # Import by full URL
-  dex import --all         # Import all dex-labeled issues
-  dex import --dry-run     # Preview without importing
-  dex import #123 --update # Update existing task from GitHub
+  dex import #123            # Import GitHub issue #123
+  dex import sc#123          # Import Shortcut story #123
+  dex import <url>           # Import by full URL
+  dex import --all           # Import all dex-labeled items
+  dex import --all --github  # Import only from GitHub
+  dex import --all --shortcut # Import only from Shortcut
+  dex import --dry-run       # Preview without importing
+  dex import #123 --update   # Update existing task
 
 ${colors.bold}ARGUMENTS:${colors.reset}
-  <ref>                   Issue reference: #N, URL, or owner/repo#N
+  <ref>                   Reference format:
+                          GitHub: #N, URL, or owner/repo#N
+                          Shortcut: sc#N, SC#N, or full URL
 
 ${colors.bold}OPTIONS:${colors.reset}
-  --all                   Import all issues with dex label
+  --all                   Import all items with dex label
+  --github                Filter --all to only GitHub
+  --shortcut              Filter --all to only Shortcut
   --update                Update existing task if already imported
   --dry-run               Show what would be imported without making changes
   -h, --help              Show this help message
 
 ${colors.bold}REQUIREMENTS:${colors.reset}
-  - Git repository with GitHub remote (for #N syntax)
-  - GitHub authentication (GITHUB_TOKEN env var or 'gh auth login')
+  GitHub:
+    - Git repository with GitHub remote (for #N syntax)
+    - GitHub authentication (GITHUB_TOKEN env var or 'gh auth login')
+
+  Shortcut:
+    - SHORTCUT_API_TOKEN environment variable
 
 ${colors.bold}EXAMPLE:${colors.reset}
-  dex import #42                              # Import issue from current repo
+  dex import #42                              # Import GitHub issue
+  dex import sc#123                           # Import Shortcut story
   dex import https://github.com/user/repo/issues/42
-  dex import user/repo#42
-  dex import --all                            # Import all dex issues
-  dex import #42 --update                     # Refresh local task from GitHub
+  dex import https://app.shortcut.com/myorg/story/123
+  dex import --all                            # Import all dex items
+  dex import --all --shortcut                 # Import all from Shortcut
+  dex import #42 --update                     # Refresh local task
 `);
     return;
   }
 
-  const issueRef = positional[0];
+  const ref = positional[0];
   const importAll = getBooleanFlag(flags, "all");
   const dryRun = getBooleanFlag(flags, "dry-run");
   const update = getBooleanFlag(flags, "update");
+  const githubOnly = getBooleanFlag(flags, "github");
+  const shortcutOnly = getBooleanFlag(flags, "shortcut");
 
-  if (!issueRef && !importAll) {
+  if (!ref && !importAll) {
     console.error(
-      `${colors.red}Error:${colors.reset} Issue reference or --all required`,
+      `${colors.red}Error:${colors.reset} Reference or --all required`,
     );
-    console.error(`Usage: dex import #123 or dex import --all`);
+    console.error(
+      `Usage: dex import #123, dex import sc#123, or dex import --all`,
+    );
     process.exit(1);
   }
 
   const config = loadConfig({ storagePath: options.storage.getIdentifier() });
+  const service = createService(options);
+
+  try {
+    if (importAll) {
+      // Import all from GitHub and/or Shortcut
+      const importFromGitHub = !shortcutOnly;
+      const importFromShortcut = !githubOnly;
+
+      if (importFromGitHub) {
+        await importAllFromGitHub(service, config, dryRun, update);
+      }
+
+      if (importFromShortcut) {
+        await importAllFromShortcut(service, config, dryRun, update);
+      }
+    } else {
+      // Detect which service the reference is for
+      const shortcutRef = parseShortcutRef(ref);
+
+      if (shortcutRef) {
+        await importShortcutStory(service, config, shortcutRef, dryRun, update);
+      } else {
+        await importGitHubIssue(service, config, ref, dryRun, update);
+      }
+    }
+  } catch (err) {
+    console.error(formatCliError(err));
+    process.exit(1);
+  }
+}
+
+/**
+ * Parse a Shortcut story reference.
+ * Supports: sc#123, SC#123, https://app.shortcut.com/{workspace}/story/123
+ * Returns { storyId, workspace? } or null if not a Shortcut reference.
+ */
+function parseShortcutRef(
+  ref: string,
+): { storyId: number; workspace?: string } | null {
+  // sc#123 or SC#123 format
+  const scMatch = ref.match(/^sc#(\d+)$/i);
+  if (scMatch) {
+    return { storyId: parseInt(scMatch[1], 10) };
+  }
+
+  // Full URL format: https://app.shortcut.com/{workspace}/story/123
+  const urlMatch = ref.match(
+    /^https?:\/\/app\.shortcut\.com\/([^/]+)\/story\/(\d+)/i,
+  );
+  if (urlMatch) {
+    return { storyId: parseInt(urlMatch[2], 10), workspace: urlMatch[1] };
+  }
+
+  return null;
+}
+
+// ============================================================
+// GitHub Import Functions
+// ============================================================
+
+async function importGitHubIssue(
+  service: ReturnType<typeof createService>,
+  config: ReturnType<typeof loadConfig>,
+  issueRef: string,
+  dryRun: boolean,
+  update: boolean,
+): Promise<void> {
   const tokenEnv = config.sync?.github?.token_env || "GITHUB_TOKEN";
   const token = getGitHubToken(tokenEnv);
 
@@ -90,28 +183,6 @@ ${colors.bold}EXAMPLE:${colors.reset}
   }
 
   const octokit = new Octokit({ auth: token });
-  const service = createService(options);
-  const labelPrefix = config.sync?.github?.label_prefix || "dex";
-
-  try {
-    if (importAll) {
-      await importAllIssues(octokit, service, labelPrefix, dryRun, update);
-    } else {
-      await importSingleIssue(octokit, service, issueRef, dryRun, update);
-    }
-  } catch (err) {
-    console.error(formatCliError(err));
-    process.exit(1);
-  }
-}
-
-async function importSingleIssue(
-  octokit: Octokit,
-  service: ReturnType<typeof createService>,
-  issueRef: string,
-  dryRun: boolean,
-  update: boolean,
-): Promise<void> {
   const defaultRepo = getGitHubRepo();
   const parsed = parseGitHubIssueRef(issueRef, defaultRepo ?? undefined);
 
@@ -141,12 +212,12 @@ async function importSingleIssue(
       if (dryRun) {
         console.log(
           `Would update task ${colors.bold}${alreadyImported.id}${colors.reset} ` +
-            `from issue #${parsed.number}`,
+            `from GitHub issue #${parsed.number}`,
         );
         return;
       }
 
-      const updatedTask = await updateTaskFromIssue(
+      const updatedTask = await updateTaskFromGitHubIssue(
         service,
         alreadyImported,
         issue,
@@ -154,13 +225,13 @@ async function importSingleIssue(
       );
       console.log(
         `${colors.green}Updated${colors.reset} task ${colors.bold}${updatedTask.id}${colors.reset} ` +
-          `from issue #${parsed.number}`,
+          `from GitHub issue #${parsed.number}`,
       );
       return;
     }
 
     console.log(
-      `${colors.yellow}Skipped${colors.reset} issue #${parsed.number}: ` +
+      `${colors.yellow}Skipped${colors.reset} GitHub issue #${parsed.number}: ` +
         `already imported as task ${colors.bold}${alreadyImported.id}${colors.reset}\n` +
         `  Use --update to refresh from GitHub`,
     );
@@ -172,7 +243,7 @@ async function importSingleIssue(
 
   if (dryRun) {
     console.log(
-      `Would import from ${colors.cyan}${parsed.owner}/${parsed.repo}${colors.reset}:`,
+      `Would import from GitHub ${colors.cyan}${parsed.owner}/${parsed.repo}${colors.reset}:`,
     );
     console.log(`  #${issue.number}: ${issue.title}`);
     if (subtasks.length > 0) {
@@ -181,14 +252,13 @@ async function importSingleIssue(
     return;
   }
 
-  const task = await importIssueAsTask(service, issue, parsed);
+  const task = await importGitHubIssueAsTask(service, issue, parsed);
   console.log(
     `${colors.green}Imported${colors.reset} issue #${parsed.number} as task ` +
       `${colors.bold}${task.id}${colors.reset}: "${task.name}"`,
   );
 
   if (subtasks.length > 0) {
-    // Track ID mapping: original ID -> local ID (for hierarchy reconstruction)
     const idMapping = new Map<string, string>();
 
     for (const subtask of subtasks) {
@@ -216,21 +286,32 @@ async function importSingleIssue(
   }
 }
 
-async function importAllIssues(
-  octokit: Octokit,
+async function importAllFromGitHub(
   service: ReturnType<typeof createService>,
-  labelPrefix: string,
+  config: ReturnType<typeof loadConfig>,
   dryRun: boolean,
   update: boolean,
 ): Promise<void> {
+  const tokenEnv = config.sync?.github?.token_env || "GITHUB_TOKEN";
+  const token = getGitHubToken(tokenEnv);
+
+  if (!token) {
+    console.warn(
+      `${colors.yellow}Warning:${colors.reset} GitHub token not found, skipping GitHub import.`,
+    );
+    return;
+  }
+
   const repo = getGitHubRepo();
   if (!repo) {
-    console.error(
-      `${colors.red}Error:${colors.reset} Cannot determine GitHub repository.\n` +
-        `This directory is not in a git repository with a GitHub remote.`,
+    console.warn(
+      `${colors.yellow}Warning:${colors.reset} No GitHub remote found, skipping GitHub import.`,
     );
-    process.exit(1);
+    return;
   }
+
+  const octokit = new Octokit({ auth: token });
+  const labelPrefix = config.sync?.github?.label_prefix || "dex";
 
   // Fetch all issues with dex label
   const { data: issues } = await octokit.issues.listForRepo({
@@ -246,7 +327,7 @@ async function importAllIssues(
 
   if (realIssues.length === 0) {
     console.log(
-      `No issues with "${labelPrefix}" label found in ${repo.owner}/${repo.repo}.`,
+      `No GitHub issues with "${labelPrefix}" label found in ${repo.owner}/${repo.repo}.`,
     );
     return;
   }
@@ -268,7 +349,7 @@ async function importAllIssues(
   if (dryRun) {
     if (toImport.length > 0) {
       console.log(
-        `Would import ${toImport.length} issue(s) from ${colors.cyan}${repo.owner}/${repo.repo}${colors.reset}:`,
+        `Would import ${toImport.length} GitHub issue(s) from ${colors.cyan}${repo.owner}/${repo.repo}${colors.reset}:`,
       );
       for (const issue of toImport) {
         console.log(`  #${issue.number}: ${issue.title}`);
@@ -276,7 +357,7 @@ async function importAllIssues(
     }
     if (toUpdate.length > 0) {
       console.log(
-        `Would update ${toUpdate.length} task(s) from ${colors.cyan}${repo.owner}/${repo.repo}${colors.reset}:`,
+        `Would update ${toUpdate.length} task(s) from GitHub ${colors.cyan}${repo.owner}/${repo.repo}${colors.reset}:`,
       );
       for (const issue of toUpdate) {
         const existingTask = importedByNumber.get(issue.number)!;
@@ -293,24 +374,24 @@ async function importAllIssues(
   let updated = 0;
 
   for (const issue of toImport) {
-    const task = await importIssueAsTask(service, issue, repo);
+    const task = await importGitHubIssueAsTask(service, issue, repo);
     console.log(
-      `${colors.green}Imported${colors.reset} #${issue.number} as ${colors.bold}${task.id}${colors.reset}`,
+      `${colors.green}Imported${colors.reset} GitHub #${issue.number} as ${colors.bold}${task.id}${colors.reset}`,
     );
     imported++;
   }
 
   for (const issue of toUpdate) {
     const existingTask = importedByNumber.get(issue.number)!;
-    await updateTaskFromIssue(service, existingTask, issue, repo);
+    await updateTaskFromGitHubIssue(service, existingTask, issue, repo);
     console.log(
-      `${colors.green}Updated${colors.reset} #${issue.number} → ${colors.bold}${existingTask.id}${colors.reset}`,
+      `${colors.green}Updated${colors.reset} GitHub #${issue.number} → ${colors.bold}${existingTask.id}${colors.reset}`,
     );
     updated++;
   }
 
   console.log(
-    `\nImported ${imported}, updated ${updated} issue(s) from ${colors.cyan}${repo.owner}/${repo.repo}${colors.reset}`,
+    `\nGitHub: Imported ${imported}, updated ${updated} issue(s) from ${colors.cyan}${repo.owner}/${repo.repo}${colors.reset}`,
   );
   if (skipped > 0) {
     console.log(
@@ -326,8 +407,8 @@ type GitHubIssue = {
   state: string;
 };
 
-interface ParsedIssueData {
-  cleanContext: string;
+interface ParsedGitHubIssueData {
+  cleanDescription: string;
   rootMetadata: ReturnType<typeof parseRootTaskMetadata>;
   githubMetadata: {
     issueNumber: number;
@@ -336,12 +417,15 @@ interface ParsedIssueData {
   };
 }
 
-function parseIssueData(issue: GitHubIssue, repo: GitHubRepo): ParsedIssueData {
+function parseGitHubIssueData(
+  issue: GitHubIssue,
+  repo: GitHubRepo,
+): ParsedGitHubIssueData {
   const body = issue.body || "";
   const { description } = parseHierarchicalIssueBody(body);
 
   // Remove dex:task: comments (both new format dex:task:key:value and legacy dex:task:id)
-  const cleanContext = description
+  const cleanDescription = description
     .replace(/<!-- dex:task:[^\s]+ -->\n?/g, "")
     .trim();
 
@@ -349,7 +433,7 @@ function parseIssueData(issue: GitHubIssue, repo: GitHubRepo): ParsedIssueData {
   const repoString = `${repo.owner}/${repo.repo}`;
 
   return {
-    cleanContext,
+    cleanDescription,
     rootMetadata,
     githubMetadata: {
       issueNumber: issue.number,
@@ -359,17 +443,14 @@ function parseIssueData(issue: GitHubIssue, repo: GitHubRepo): ParsedIssueData {
   };
 }
 
-async function importIssueAsTask(
+async function importGitHubIssueAsTask(
   service: ReturnType<typeof createService>,
   issue: GitHubIssue,
   repo: GitHubRepo,
 ): Promise<Task> {
-  const { cleanContext, rootMetadata, githubMetadata } = parseIssueData(
-    issue,
-    repo,
-  );
+  const { cleanDescription, rootMetadata, githubMetadata } =
+    parseGitHubIssueData(issue, repo);
 
-  // Determine completion status: prefer metadata, fall back to issue state
   const completed = rootMetadata?.completed ?? issue.state === "closed";
 
   const metadata = {
@@ -380,7 +461,8 @@ async function importIssueAsTask(
   return await service.create({
     id: rootMetadata?.id, // Use original ID if available (will fail if conflict)
     name: issue.title,
-    description: cleanContext || `Imported from GitHub issue #${issue.number}`,
+    description:
+      cleanDescription || `Imported from GitHub issue #${issue.number}`,
     priority: rootMetadata?.priority,
     completed,
     result:
@@ -393,23 +475,21 @@ async function importIssueAsTask(
   });
 }
 
-async function updateTaskFromIssue(
+async function updateTaskFromGitHubIssue(
   service: ReturnType<typeof createService>,
   existingTask: Task,
   issue: GitHubIssue,
   repo: GitHubRepo,
 ): Promise<Task> {
-  const { cleanContext, rootMetadata, githubMetadata } = parseIssueData(
-    issue,
-    repo,
-  );
+  const { cleanDescription, rootMetadata, githubMetadata } =
+    parseGitHubIssueData(issue, repo);
 
   const isClosed = issue.state === "closed";
 
   return await service.update({
     id: existingTask.id,
     name: issue.title,
-    description: cleanContext || existingTask.description,
+    description: cleanDescription || existingTask.description,
     priority: rootMetadata?.priority ?? existingTask.priority,
     metadata: {
       ...existingTask.metadata,
@@ -421,6 +501,279 @@ async function updateTaskFromIssue(
       ? rootMetadata?.result ||
         existingTask.result ||
         "Updated from closed GitHub issue"
+      : undefined,
+  });
+}
+
+// ============================================================
+// Shortcut Import Functions
+// ============================================================
+
+async function importShortcutStory(
+  service: ReturnType<typeof createService>,
+  config: ReturnType<typeof loadConfig>,
+  ref: { storyId: number; workspace?: string },
+  dryRun: boolean,
+  update: boolean,
+): Promise<void> {
+  const tokenEnv = config.sync?.shortcut?.token_env || "SHORTCUT_API_TOKEN";
+  const token = getShortcutToken(tokenEnv);
+
+  if (!token) {
+    console.error(
+      `${colors.red}Error:${colors.reset} Shortcut API token not found.\n` +
+        `Set the ${tokenEnv} environment variable.`,
+    );
+    process.exit(1);
+  }
+
+  const api = new ShortcutApi(token);
+
+  // Fetch the story
+  const story = await api.getStory(ref.storyId);
+  const workspace = ref.workspace || (await api.getWorkspaceSlug());
+
+  // Check if already imported
+  const existingTasks = await service.list({ all: true });
+  const alreadyImported = existingTasks.find(
+    (t) => getShortcutStoryId(t) === story.id,
+  );
+
+  if (alreadyImported) {
+    if (update) {
+      if (dryRun) {
+        console.log(
+          `Would update task ${colors.bold}${alreadyImported.id}${colors.reset} ` +
+            `from Shortcut story #${story.id}`,
+        );
+        return;
+      }
+
+      const updatedTask = await updateTaskFromShortcutStory(
+        service,
+        alreadyImported,
+        story,
+        workspace,
+      );
+      console.log(
+        `${colors.green}Updated${colors.reset} task ${colors.bold}${updatedTask.id}${colors.reset} ` +
+          `from Shortcut story #${story.id}`,
+      );
+      return;
+    }
+
+    console.log(
+      `${colors.yellow}Skipped${colors.reset} Shortcut story #${story.id}: ` +
+        `already imported as task ${colors.bold}${alreadyImported.id}${colors.reset}\n` +
+        `  Use --update to refresh from Shortcut`,
+    );
+    return;
+  }
+
+  if (dryRun) {
+    console.log(
+      `Would import from Shortcut ${colors.cyan}${workspace}${colors.reset}:`,
+    );
+    console.log(`  #${story.id}: ${story.name}`);
+    return;
+  }
+
+  const task = await importShortcutStoryAsTask(service, story, workspace);
+  console.log(
+    `${colors.green}Imported${colors.reset} Shortcut story #${story.id} as task ` +
+      `${colors.bold}${task.id}${colors.reset}: "${task.name}"`,
+  );
+}
+
+async function importAllFromShortcut(
+  service: ReturnType<typeof createService>,
+  config: ReturnType<typeof loadConfig>,
+  dryRun: boolean,
+  update: boolean,
+): Promise<void> {
+  const tokenEnv = config.sync?.shortcut?.token_env || "SHORTCUT_API_TOKEN";
+  const token = getShortcutToken(tokenEnv);
+
+  if (!token) {
+    console.warn(
+      `${colors.yellow}Warning:${colors.reset} Shortcut API token not found, skipping Shortcut import.`,
+    );
+    return;
+  }
+
+  const api = new ShortcutApi(token);
+  const label = config.sync?.shortcut?.label || "dex";
+  const workspace =
+    config.sync?.shortcut?.workspace || (await api.getWorkspaceSlug());
+
+  // Search for stories with dex label
+  const response = await api.searchStories(`label:"${label}"`);
+  const stories = response.data;
+
+  if (stories.length === 0) {
+    console.log(
+      `No Shortcut stories with "${label}" label found in ${workspace}.`,
+    );
+    return;
+  }
+
+  // Get existing tasks to check for duplicates
+  const existingTasks = await service.list({ all: true });
+  const importedById = new Map(
+    existingTasks
+      .map((t) => [getShortcutStoryId(t), t] as const)
+      .filter((pair): pair is [number, Task] => pair[0] !== null),
+  );
+
+  const toImport = stories.filter((s) => !importedById.has(s.id));
+  const toUpdate = update ? stories.filter((s) => importedById.has(s.id)) : [];
+  const skipped = stories.length - toImport.length - toUpdate.length;
+
+  if (dryRun) {
+    if (toImport.length > 0) {
+      console.log(
+        `Would import ${toImport.length} Shortcut story(ies) from ${colors.cyan}${workspace}${colors.reset}:`,
+      );
+      for (const story of toImport) {
+        console.log(`  #${story.id}: ${story.name}`);
+      }
+    }
+    if (toUpdate.length > 0) {
+      console.log(
+        `Would update ${toUpdate.length} task(s) from Shortcut ${colors.cyan}${workspace}${colors.reset}:`,
+      );
+      for (const story of toUpdate) {
+        const existingTask = importedById.get(story.id)!;
+        console.log(`  #${story.id} → ${existingTask.id}`);
+      }
+    }
+    if (skipped > 0) {
+      console.log(`  (${skipped} already imported, use --update to refresh)`);
+    }
+    return;
+  }
+
+  let imported = 0;
+  let updated = 0;
+
+  for (const story of toImport) {
+    const task = await importShortcutStoryAsTask(service, story, workspace);
+    console.log(
+      `${colors.green}Imported${colors.reset} Shortcut #${story.id} as ${colors.bold}${task.id}${colors.reset}`,
+    );
+    imported++;
+  }
+
+  for (const story of toUpdate) {
+    const existingTask = importedById.get(story.id)!;
+    await updateTaskFromShortcutStory(service, existingTask, story, workspace);
+    console.log(
+      `${colors.green}Updated${colors.reset} Shortcut #${story.id} → ${colors.bold}${existingTask.id}${colors.reset}`,
+    );
+    updated++;
+  }
+
+  console.log(
+    `\nShortcut: Imported ${imported}, updated ${updated} story(ies) from ${colors.cyan}${workspace}${colors.reset}`,
+  );
+  if (skipped > 0) {
+    console.log(
+      `Skipped ${skipped} already imported (use --update to refresh)`,
+    );
+  }
+}
+
+type ShortcutStory = {
+  id: number;
+  name: string;
+  description?: string;
+  completed: boolean;
+  app_url: string;
+};
+
+interface ParsedShortcutStoryData {
+  cleanDescription: string;
+  taskMetadata: ReturnType<typeof parseShortcutTaskMetadata>;
+  shortcutMetadata: ShortcutMetadata;
+}
+
+function parseShortcutStoryData(
+  story: ShortcutStory,
+  workspace: string,
+): ParsedShortcutStoryData {
+  const { context: cleanDescription, metadata: taskMetadata } =
+    parseStoryDescription(story.description ?? "");
+
+  const shortcutMetadata: ShortcutMetadata = {
+    storyId: story.id,
+    storyUrl: story.app_url,
+    workspace,
+    state: story.completed ? "done" : "unstarted",
+  };
+
+  return {
+    cleanDescription,
+    taskMetadata,
+    shortcutMetadata,
+  };
+}
+
+async function importShortcutStoryAsTask(
+  service: ReturnType<typeof createService>,
+  story: ShortcutStory,
+  workspace: string,
+): Promise<Task> {
+  const { cleanDescription, taskMetadata, shortcutMetadata } =
+    parseShortcutStoryData(story, workspace);
+
+  const completed = taskMetadata?.completed ?? story.completed;
+
+  const metadata = {
+    shortcut: shortcutMetadata,
+    commit: taskMetadata?.commit,
+  };
+
+  return await service.create({
+    id: taskMetadata?.id,
+    name: story.name,
+    description:
+      cleanDescription || `Imported from Shortcut story #${story.id}`,
+    priority: taskMetadata?.priority,
+    completed,
+    result:
+      taskMetadata?.result ??
+      (completed ? "Imported as completed from Shortcut" : null),
+    metadata,
+    created_at: taskMetadata?.created_at,
+    updated_at: taskMetadata?.updated_at,
+    completed_at: taskMetadata?.completed_at,
+  });
+}
+
+async function updateTaskFromShortcutStory(
+  service: ReturnType<typeof createService>,
+  existingTask: Task,
+  story: ShortcutStory,
+  workspace: string,
+): Promise<Task> {
+  const { cleanDescription, taskMetadata, shortcutMetadata } =
+    parseShortcutStoryData(story, workspace);
+
+  return await service.update({
+    id: existingTask.id,
+    name: story.name,
+    description: cleanDescription || existingTask.description,
+    priority: taskMetadata?.priority ?? existingTask.priority,
+    metadata: {
+      ...existingTask.metadata,
+      shortcut: shortcutMetadata,
+      commit: taskMetadata?.commit,
+    },
+    completed: story.completed,
+    result: story.completed
+      ? taskMetadata?.result ||
+        existingTask.result ||
+        "Updated from completed Shortcut story"
       : undefined,
   });
 }

--- a/src/cli/init.ts
+++ b/src/cli/init.ts
@@ -136,6 +136,14 @@ engine = "file"
 # enabled = true
 # token_env = "GITHUB_TOKEN"    # Environment variable containing GitHub token (or use gh CLI)
 # label_prefix = "dex"           # Prefix for dex-related labels
+
+# Shortcut sync (optional - sync tasks with Shortcut Stories)
+# [sync.shortcut]
+# enabled = true
+# token_env = "SHORTCUT_API_TOKEN"  # Environment variable containing Shortcut API token
+# team = "engineering"               # Team mention name or UUID (required)
+# workspace = "mycompany"            # Workspace slug (auto-detected if not set)
+# label = "dex"                      # Label for dex stories
 `;
 
   fs.writeFileSync(configPath, defaultConfig, "utf-8");

--- a/src/cli/test-helpers.ts
+++ b/src/cli/test-helpers.ts
@@ -21,6 +21,17 @@ export {
   type GitHubMock,
 } from "../test-utils/github-mock.js";
 
+export {
+  setupShortcutMock,
+  cleanupShortcutMock,
+  createStoryFixture,
+  createWorkflowFixture,
+  createTeamFixture,
+  createMemberFixture,
+  type ShortcutStoryFixture,
+  type ShortcutMock,
+} from "../test-utils/shortcut-mock.js";
+
 /**
  * Create an ArchivedTask with sensible defaults for testing.
  */

--- a/src/core/config.ts
+++ b/src/core/config.ts
@@ -34,11 +34,31 @@ export interface GitHubSyncConfig {
 }
 
 /**
+ * Shortcut sync configuration.
+ */
+export interface ShortcutSyncConfig {
+  /** Enable automatic Shortcut sync on task create/update (default: false) */
+  enabled?: boolean;
+  /** Environment variable containing Shortcut API token (default: "SHORTCUT_API_TOKEN") */
+  token_env?: string;
+  /** Shortcut workspace slug (inferred from API if not set) */
+  workspace?: string;
+  /** Team ID or mention name for story creation (required for auto-sync) */
+  team?: string;
+  /** Workflow ID to use (uses team default if not set) */
+  workflow?: number;
+  /** Label name for dex stories (default: "dex") */
+  label?: string;
+}
+
+/**
  * Sync configuration
  */
 export interface SyncConfig {
   /** GitHub sync settings */
   github?: GitHubSyncConfig;
+  /** Shortcut sync settings */
+  shortcut?: ShortcutSyncConfig;
 }
 
 /**
@@ -170,7 +190,7 @@ function mergeSyncConfig(
 ): SyncConfig | undefined {
   if (b === undefined) return a;
 
-  const mergedAuto =
+  const mergedGitHubAuto =
     b.github?.auto !== undefined
       ? { ...a?.github?.auto, ...b.github.auto }
       : a?.github?.auto;
@@ -179,7 +199,11 @@ function mergeSyncConfig(
     github: {
       ...a?.github,
       ...b.github,
-      auto: mergedAuto,
+      auto: mergedGitHubAuto,
+    },
+    shortcut: {
+      ...a?.shortcut,
+      ...b.shortcut,
     },
   };
 }

--- a/src/core/shortcut/api.ts
+++ b/src/core/shortcut/api.ts
@@ -1,0 +1,260 @@
+/**
+ * Shortcut API wrapper using the official @shortcut/client library.
+ * Provides a simplified interface for dex integration.
+ */
+
+import {
+  ShortcutClient,
+  type Story,
+  type StorySearchResult,
+  type Workflow,
+  type Group,
+  type Label,
+  type MemberInfo,
+  type CreateStoryParams,
+  type UpdateStory,
+  type StorySearchResults,
+  type WorkflowState,
+} from "@shortcut/client";
+
+// Re-export types that are used externally
+export type {
+  Story,
+  StorySearchResult,
+  Workflow,
+  WorkflowState,
+  Label,
+  MemberInfo,
+};
+
+export interface ShortcutTeam {
+  id: string;
+  name: string;
+  mention_name: string;
+  workflow_ids: number[];
+}
+
+export interface SearchStoriesResponse {
+  data: StorySearchResult[];
+  next?: string;
+  total: number;
+}
+
+/**
+ * Shortcut API wrapper for dex integration.
+ * Uses the official @shortcut/client library.
+ */
+export class ShortcutApi {
+  private client: ShortcutClient;
+  private workspaceSlug: string | null = null;
+
+  constructor(token: string, workspace?: string) {
+    this.client = new ShortcutClient(token);
+    this.workspaceSlug = workspace || null;
+  }
+
+  /**
+   * Get the current member info (includes workspace slug).
+   */
+  async getCurrentMember(): Promise<MemberInfo> {
+    const response = await this.client.getCurrentMemberInfo();
+    return response.data;
+  }
+
+  /**
+   * Get or fetch the workspace slug.
+   */
+  async getWorkspaceSlug(): Promise<string> {
+    if (this.workspaceSlug) {
+      return this.workspaceSlug;
+    }
+    const member = await this.getCurrentMember();
+    this.workspaceSlug = member.workspace2.url_slug;
+    return this.workspaceSlug;
+  }
+
+  /**
+   * Create a new story.
+   */
+  async createStory(data: CreateStoryParams): Promise<Story> {
+    const response = await this.client.createStory(data);
+    return response.data;
+  }
+
+  /**
+   * Update an existing story.
+   */
+  async updateStory(storyId: number, data: UpdateStory): Promise<Story> {
+    const response = await this.client.updateStory(storyId, data);
+    return response.data;
+  }
+
+  /**
+   * Get a story by ID.
+   */
+  async getStory(storyId: number): Promise<Story> {
+    const response = await this.client.getStory(storyId);
+    return response.data;
+  }
+
+  /**
+   * Search for stories.
+   */
+  async searchStories(query: string): Promise<SearchStoriesResponse> {
+    const response = await this.client.searchStories({
+      query,
+      page_size: 100,
+    });
+    const results: StorySearchResults = response.data;
+    return {
+      data: results.data,
+      next: results.next ?? undefined,
+      total: results.total,
+    };
+  }
+
+  /**
+   * Create a sub-story (story with parent relationship).
+   * Creates a story with parent_story_id to link it as a sub-task.
+   */
+  async createSubStory(
+    parentStoryId: number,
+    data: CreateStoryParams,
+  ): Promise<Story> {
+    // Create the story with parent_story_id to make it a sub-task
+    const response = await this.client.createStory({
+      ...data,
+      parent_story_id: parentStoryId,
+    });
+    return response.data;
+  }
+
+  /**
+   * Add an existing story as a sub-story of another story.
+   */
+  async addSubStory(parentStoryId: number, subStoryId: number): Promise<void> {
+    // Update the child story to set its parent
+    await this.client.updateStory(subStoryId, {
+      parent_story_id: parentStoryId,
+    });
+  }
+
+  /**
+   * Remove a story from its parent (convert sub-story to regular story).
+   */
+  async removeSubStory(subStoryId: number): Promise<void> {
+    await this.client.updateStory(subStoryId, {
+      parent_story_id: null,
+    });
+  }
+
+  /**
+   * Get a workflow by ID.
+   */
+  async getWorkflow(workflowId: number): Promise<Workflow> {
+    const response = await this.client.getWorkflow(workflowId);
+    return response.data;
+  }
+
+  /**
+   * List all workflows.
+   */
+  async listWorkflows(): Promise<Workflow[]> {
+    const response = await this.client.listWorkflows();
+    return response.data;
+  }
+
+  /**
+   * List all teams (groups in Shortcut API).
+   */
+  async listTeams(): Promise<ShortcutTeam[]> {
+    const response = await this.client.listGroups();
+    return response.data.map((g: Group) => ({
+      id: g.id,
+      name: g.name,
+      mention_name: g.mention_name,
+      workflow_ids: g.workflow_ids,
+    }));
+  }
+
+  /**
+   * Get a team by ID.
+   */
+  async getTeam(teamId: string): Promise<ShortcutTeam> {
+    const response = await this.client.getGroup(teamId);
+    const g = response.data;
+    return {
+      id: g.id,
+      name: g.name,
+      mention_name: g.mention_name,
+      workflow_ids: g.workflow_ids,
+    };
+  }
+
+  /**
+   * Find a team by mention name.
+   */
+  async findTeamByMentionName(
+    mentionName: string,
+  ): Promise<ShortcutTeam | null> {
+    const teams = await this.listTeams();
+    return (
+      teams.find(
+        (t) => t.mention_name === mentionName || t.name === mentionName,
+      ) || null
+    );
+  }
+
+  /**
+   * List all labels.
+   */
+  async listLabels(): Promise<Label[]> {
+    const response = await this.client.listLabels();
+    return response.data;
+  }
+
+  /**
+   * Create a label if it doesn't exist.
+   */
+  async ensureLabel(name: string): Promise<Label> {
+    const labels = await this.listLabels();
+    const existing = labels.find((l) => l.name === name);
+    if (existing) {
+      return existing;
+    }
+    const response = await this.client.createLabel({ name });
+    return response.data;
+  }
+
+  /**
+   * Get the default "unstarted" state for a workflow.
+   */
+  async getDefaultUnstartedState(workflowId: number): Promise<number> {
+    const workflow = await this.getWorkflow(workflowId);
+    const unstartedState = workflow.states.find((s) => s.type === "unstarted");
+    if (!unstartedState) {
+      throw new Error(`No unstarted state found in workflow ${workflowId}`);
+    }
+    return unstartedState.id;
+  }
+
+  /**
+   * Get the "done" state for a workflow.
+   */
+  async getDoneState(workflowId: number): Promise<number> {
+    const workflow = await this.getWorkflow(workflowId);
+    const doneState = workflow.states.find((s) => s.type === "done");
+    if (!doneState) {
+      throw new Error(`No done state found in workflow ${workflowId}`);
+    }
+    return doneState.id;
+  }
+
+  /**
+   * Build the story URL from story ID.
+   */
+  async buildStoryUrl(storyId: number): Promise<string> {
+    const workspace = await this.getWorkspaceSlug();
+    return `https://app.shortcut.com/${workspace}/story/${storyId}`;
+  }
+}

--- a/src/core/shortcut/index.ts
+++ b/src/core/shortcut/index.ts
@@ -1,0 +1,31 @@
+// Shortcut integration - public API only
+// Internal utilities should be imported directly from their source files
+
+export { getShortcutToken } from "./token.js";
+export { ShortcutApi, type ShortcutTeam } from "./api.js";
+
+// Re-export @shortcut/client types that are used externally
+export type {
+  Story as ShortcutStory,
+  StorySearchResult,
+  Workflow as ShortcutWorkflow,
+  WorkflowState,
+  Label as ShortcutLabel,
+  MemberInfo,
+} from "./api.js";
+
+export {
+  ShortcutSyncService,
+  type SyncResult,
+  type SyncProgress,
+  getShortcutStoryId,
+} from "./sync.js";
+export {
+  createShortcutSyncService,
+  createShortcutSyncServiceOrThrow,
+} from "./sync-factory.js";
+export {
+  parseTaskMetadata,
+  parseStoryDescription,
+  renderStoryDescription,
+} from "./story-markdown.js";

--- a/src/core/shortcut/story-markdown.ts
+++ b/src/core/shortcut/story-markdown.ts
@@ -1,0 +1,200 @@
+import type { Task, CommitMetadata, ShortcutMetadata } from "../../types.js";
+
+/**
+ * Encode a potentially multi-line value for storage in HTML comments.
+ * Uses base64 encoding if the value contains newlines or the delimiter characters.
+ */
+export function encodeMetadataValue(value: string): string {
+  // If the value contains newlines, --> (which would break HTML comment), or
+  // starts with "base64:" (which is our encoding marker), encode it
+  if (
+    value.includes("\n") ||
+    value.includes("-->") ||
+    value.startsWith("base64:")
+  ) {
+    return `base64:${Buffer.from(value, "utf-8").toString("base64")}`;
+  }
+  return value;
+}
+
+/**
+ * Decode a metadata value that may be base64 encoded.
+ */
+export function decodeMetadataValue(value: string): string {
+  if (value.startsWith("base64:")) {
+    return Buffer.from(value.slice(7), "base64").toString("utf-8");
+  }
+  return value;
+}
+
+/**
+ * Parsed task metadata from a Shortcut story description.
+ */
+export interface ParsedTaskMetadata {
+  id?: string;
+  priority?: number;
+  completed?: boolean;
+  created_at?: string;
+  updated_at?: string;
+  completed_at?: string | null;
+  result?: string | null;
+  commit?: CommitMetadata;
+  shortcut?: ShortcutMetadata;
+  parent_id?: string;
+}
+
+/**
+ * Parse task metadata from HTML comments in a story description.
+ * Extracts metadata encoded with <!-- dex:task:key:value --> format.
+ * @param description - The Shortcut story description
+ * @returns Parsed metadata or null if no dex task metadata found
+ */
+export function parseTaskMetadata(
+  description: string,
+): ParsedTaskMetadata | null {
+  const metadata: ParsedTaskMetadata = {};
+  const commit: Partial<CommitMetadata> = {};
+  let foundAny = false;
+
+  // Match all dex:task: comments (root task metadata uses dex:task: prefix)
+  const commentRegex = /<!-- dex:task:(\w+):(.*?) -->/g;
+  let match;
+
+  while ((match = commentRegex.exec(description)) !== null) {
+    foundAny = true;
+    const [, key, rawValue] = match;
+    const value = decodeMetadataValue(rawValue);
+
+    switch (key) {
+      case "id":
+        metadata.id = value;
+        break;
+      case "parent_id":
+        metadata.parent_id = value;
+        break;
+      case "priority":
+        metadata.priority = parseInt(value, 10);
+        break;
+      case "completed":
+        metadata.completed = value === "true";
+        break;
+      case "created_at":
+        metadata.created_at = value;
+        break;
+      case "updated_at":
+        metadata.updated_at = value;
+        break;
+      case "completed_at":
+        metadata.completed_at = value === "null" ? null : value;
+        break;
+      case "result":
+        metadata.result = value;
+        break;
+      case "commit_sha":
+        commit.sha = value;
+        break;
+      case "commit_message":
+        commit.message = value;
+        break;
+      case "commit_branch":
+        commit.branch = value;
+        break;
+      case "commit_url":
+        commit.url = value;
+        break;
+      case "commit_timestamp":
+        commit.timestamp = value;
+        break;
+    }
+  }
+
+  if (!foundAny) {
+    return null;
+  }
+
+  // Only add commit metadata if we have at least a SHA
+  if (commit.sha) {
+    metadata.commit = commit as CommitMetadata;
+  }
+
+  return metadata;
+}
+
+/**
+ * Result of parsing a story description.
+ */
+export interface ParsedStoryDescription {
+  context: string;
+  metadata: ParsedTaskMetadata | null;
+}
+
+/**
+ * Parse a story description to extract context and metadata.
+ * @param description - The Shortcut story description
+ * @returns Parsed context and metadata
+ */
+export function parseStoryDescription(
+  description: string,
+): ParsedStoryDescription {
+  const metadata = parseTaskMetadata(description);
+
+  // Remove all dex:task: comments to get clean context
+  const cleanContext = description
+    .replace(/<!-- dex:task:[^\s]+ -->\n?/g, "")
+    .trim();
+
+  return { context: cleanContext, metadata };
+}
+
+/**
+ * Render a story description with embedded task metadata.
+ * @param task - The task to render
+ * @returns The rendered story description
+ */
+export function renderStoryDescription(task: Task): string {
+  const lines: string[] = [];
+
+  // Add metadata comments
+  lines.push(`<!-- dex:task:id:${task.id} -->`);
+  if (task.parent_id) {
+    lines.push(`<!-- dex:task:parent_id:${task.parent_id} -->`);
+  }
+  lines.push(`<!-- dex:task:priority:${task.priority} -->`);
+  lines.push(`<!-- dex:task:completed:${task.completed} -->`);
+  lines.push(`<!-- dex:task:created_at:${task.created_at} -->`);
+  lines.push(`<!-- dex:task:updated_at:${task.updated_at} -->`);
+  lines.push(`<!-- dex:task:completed_at:${task.completed_at ?? "null"} -->`);
+
+  // Add result if present (base64 encoded for multi-line support)
+  if (task.result) {
+    lines.push(`<!-- dex:task:result:${encodeMetadataValue(task.result)} -->`);
+  }
+
+  // Add commit metadata if present
+  if (task.metadata?.commit) {
+    const commit = task.metadata.commit;
+    lines.push(`<!-- dex:task:commit_sha:${commit.sha} -->`);
+    if (commit.message) {
+      lines.push(
+        `<!-- dex:task:commit_message:${encodeMetadataValue(commit.message)} -->`,
+      );
+    }
+    if (commit.branch) {
+      lines.push(`<!-- dex:task:commit_branch:${commit.branch} -->`);
+    }
+    if (commit.url) {
+      lines.push(`<!-- dex:task:commit_url:${commit.url} -->`);
+    }
+    if (commit.timestamp) {
+      lines.push(`<!-- dex:task:commit_timestamp:${commit.timestamp} -->`);
+    }
+  }
+
+  // Add task description
+  if (task.description) {
+    lines.push("");
+    lines.push(task.description);
+  }
+
+  return lines.join("\n");
+}

--- a/src/core/shortcut/sync-factory.ts
+++ b/src/core/shortcut/sync-factory.ts
@@ -1,0 +1,99 @@
+import { ShortcutSyncService } from "./sync.js";
+import type { ShortcutSyncConfig } from "../config.js";
+import { getShortcutToken } from "./token.js";
+import { ShortcutApi } from "./api.js";
+
+/**
+ * Create a ShortcutSyncService for auto-sync if enabled in config.
+ * Returns null if auto-sync is disabled or no token.
+ *
+ * @param config Sync config from dex.toml
+ */
+export async function createShortcutSyncService(
+  config: ShortcutSyncConfig | undefined,
+): Promise<ShortcutSyncService | null> {
+  if (!config?.enabled) {
+    return null;
+  }
+
+  const tokenEnv = config.token_env || "SHORTCUT_API_TOKEN";
+  const token = getShortcutToken(tokenEnv);
+
+  if (!token) {
+    console.warn(
+      `Shortcut sync enabled but no token found (checked ${tokenEnv}). Sync disabled.`,
+    );
+    return null;
+  }
+
+  if (!config.team) {
+    console.warn(
+      "Shortcut sync enabled but no team specified in config. Sync disabled.",
+    );
+    return null;
+  }
+
+  // Get workspace from config or API
+  let workspace = config.workspace;
+  if (!workspace) {
+    try {
+      const api = new ShortcutApi(token);
+      workspace = await api.getWorkspaceSlug();
+    } catch (err) {
+      console.warn(
+        `Failed to fetch Shortcut workspace: ${err}. Sync disabled.`,
+      );
+      return null;
+    }
+  }
+
+  return new ShortcutSyncService({
+    token,
+    workspace,
+    team: config.team,
+    workflow: config.workflow,
+    label: config.label,
+  });
+}
+
+/**
+ * Create a ShortcutSyncService for manual sync/import commands.
+ * Throws descriptive errors if requirements are not met.
+ *
+ * @param config Optional sync config for label and token_env
+ */
+export async function createShortcutSyncServiceOrThrow(
+  config?: ShortcutSyncConfig,
+): Promise<ShortcutSyncService> {
+  const tokenEnv = config?.token_env || "SHORTCUT_API_TOKEN";
+  const token = getShortcutToken(tokenEnv);
+
+  if (!token) {
+    throw new Error(
+      `Shortcut API token not found.\n` +
+        `Set the ${tokenEnv} environment variable.`,
+    );
+  }
+
+  if (!config?.team) {
+    throw new Error(
+      `Shortcut team not configured.\n` +
+        `Add 'team' to [sync.shortcut] section in dex.toml.`,
+    );
+  }
+
+  // Get workspace from config or API
+  let workspace = config.workspace;
+  if (!workspace) {
+    const api = new ShortcutApi(token);
+    workspace = await api.getWorkspaceSlug();
+  }
+
+  return new ShortcutSyncService({
+    token,
+    workspace,
+    team: config.team,
+    workflow: config.workflow,
+    label: config.label,
+  });
+}

--- a/src/core/shortcut/sync.ts
+++ b/src/core/shortcut/sync.ts
@@ -1,0 +1,661 @@
+import type { ShortcutMetadata, Task, TaskStore } from "../../types.js";
+import { ShortcutApi } from "./api.js";
+import type { Workflow, WorkflowState } from "@shortcut/client";
+import { renderStoryDescription, parseTaskMetadata } from "./story-markdown.js";
+
+/**
+ * Result of syncing a task to Shortcut.
+ * Contains the shortcut metadata that should be saved to the task.
+ */
+export interface SyncResult {
+  taskId: string;
+  shortcut: ShortcutMetadata;
+  created: boolean;
+  /** True if task was skipped because nothing changed */
+  skipped?: boolean;
+}
+
+/**
+ * Progress callback for sync operations.
+ */
+export interface SyncProgress {
+  /** Current task index (1-based) */
+  current: number;
+  /** Total number of tasks */
+  total: number;
+  /** Task being processed */
+  task: Task;
+  /** Current phase of the sync */
+  phase: "checking" | "creating" | "updating" | "skipped";
+}
+
+/**
+ * Cached story data for efficient sync operations.
+ */
+export interface CachedStory {
+  id: number;
+  name: string;
+  description: string;
+  completed: boolean;
+  labels: string[];
+}
+
+export interface ShortcutSyncServiceOptions {
+  /** Shortcut API token */
+  token: string;
+  /** Shortcut workspace slug */
+  workspace: string;
+  /** Team ID or mention name for story creation */
+  team: string;
+  /** Workflow ID to use (uses team default if not set) */
+  workflow?: number;
+  /** Label name for dex stories (default: "dex") */
+  label?: string;
+}
+
+export interface SyncAllOptions {
+  /** Callback for progress updates */
+  onProgress?: (progress: SyncProgress) => void;
+  /** Whether to skip unchanged tasks (default: true) */
+  skipUnchanged?: boolean;
+}
+
+/**
+ * Shortcut Sync Service
+ *
+ * Provides one-way sync of tasks to Shortcut Stories.
+ * File storage remains the source of truth.
+ *
+ * Behavior:
+ * - Top-level tasks (no parent_id) -> Create/update Shortcut Story
+ * - Subtasks -> Create as sub-stories linked to parent story
+ * - Completed tasks -> Story moved to "done" workflow state
+ * - Pending tasks -> Story in "unstarted" or "started" state
+ */
+export class ShortcutSyncService {
+  private api: ShortcutApi;
+  private workspace: string;
+  private teamId: string;
+  private workflowId: number | undefined;
+  private label: string;
+
+  // Cached workflow states for performance
+  private workflowCache: Map<number, Workflow> = new Map();
+  private resolvedTeamId: string | null = null;
+  private resolvedWorkflowId: number | null = null;
+
+  constructor(options: ShortcutSyncServiceOptions) {
+    this.api = new ShortcutApi(options.token, options.workspace);
+    this.workspace = options.workspace;
+    this.teamId = options.team;
+    this.workflowId = options.workflow;
+    this.label = options.label || "dex";
+  }
+
+  /**
+   * Get the workspace this service syncs to.
+   */
+  getWorkspace(): string {
+    return this.workspace;
+  }
+
+  /**
+   * Resolve the team ID (handles mention names).
+   */
+  private async resolveTeamId(): Promise<string> {
+    if (this.resolvedTeamId) {
+      return this.resolvedTeamId;
+    }
+
+    // Check if it's already a UUID
+    if (this.teamId.match(/^[0-9a-f-]{36}$/i)) {
+      this.resolvedTeamId = this.teamId;
+      return this.resolvedTeamId;
+    }
+
+    // Try to find by mention name
+    const team = await this.api.findTeamByMentionName(this.teamId);
+    if (!team) {
+      throw new Error(`Team not found: ${this.teamId}`);
+    }
+
+    this.resolvedTeamId = team.id;
+    return this.resolvedTeamId;
+  }
+
+  /**
+   * Get or fetch workflow.
+   */
+  private async getWorkflow(workflowId: number): Promise<Workflow> {
+    let workflow = this.workflowCache.get(workflowId);
+    if (!workflow) {
+      workflow = await this.api.getWorkflow(workflowId);
+      this.workflowCache.set(workflowId, workflow);
+    }
+    return workflow;
+  }
+
+  /**
+   * Get the workflow ID to use for new stories.
+   */
+  private async getWorkflowId(): Promise<number> {
+    if (this.workflowId) {
+      return this.workflowId;
+    }
+
+    // Return cached value if available
+    if (this.resolvedWorkflowId !== null) {
+      return this.resolvedWorkflowId;
+    }
+
+    // Get team's default workflow
+    const teamId = await this.resolveTeamId();
+    const team = await this.api.getTeam(teamId);
+    if (team.workflow_ids.length === 0) {
+      throw new Error(`Team ${this.teamId} has no workflows`);
+    }
+    this.resolvedWorkflowId = team.workflow_ids[0];
+    return this.resolvedWorkflowId;
+  }
+
+  /**
+   * Get the appropriate workflow state ID for a task.
+   */
+  private async getWorkflowStateId(
+    task: Task,
+    workflowId: number,
+  ): Promise<number> {
+    const workflow = await this.getWorkflow(workflowId);
+
+    if (task.completed) {
+      const doneState = workflow.states.find(
+        (s: WorkflowState) => s.type === "done",
+      );
+      if (!doneState) {
+        throw new Error(`No done state found in workflow ${workflowId}`);
+      }
+      return doneState.id;
+    }
+
+    // For non-completed tasks, use unstarted state
+    const unstartedState = workflow.states.find(
+      (s: WorkflowState) => s.type === "unstarted",
+    );
+    if (!unstartedState) {
+      throw new Error(`No unstarted state found in workflow ${workflowId}`);
+    }
+    return unstartedState.id;
+  }
+
+  /**
+   * Get the workflow state type from a state ID.
+   */
+  private async getWorkflowStateType(
+    workflowId: number,
+    stateId: number,
+  ): Promise<"unstarted" | "started" | "done"> {
+    const workflow = await this.getWorkflow(workflowId);
+    const state = workflow.states.find((s: WorkflowState) => s.id === stateId);
+    return (state?.type as "unstarted" | "started" | "done") || "unstarted";
+  }
+
+  /**
+   * Sync a single task to Shortcut.
+   * For subtasks, syncs the parent story instead.
+   * Returns sync result with shortcut metadata.
+   */
+  async syncTask(task: Task, store: TaskStore): Promise<SyncResult | null> {
+    // If this is a subtask, sync the parent instead
+    if (task.parent_id) {
+      const parent = store.tasks.find((t) => t.id === task.parent_id);
+      if (parent) {
+        return this.syncTask(parent, store);
+      }
+      return null;
+    }
+
+    return this.syncParentTask(task, store);
+  }
+
+  /**
+   * Sync all tasks to Shortcut.
+   * Returns array of sync results.
+   */
+  async syncAll(
+    store: TaskStore,
+    options: SyncAllOptions = {},
+  ): Promise<SyncResult[]> {
+    const { onProgress, skipUnchanged = true } = options;
+    const results: SyncResult[] = [];
+    const parentTasks = store.tasks.filter((t) => !t.parent_id);
+    const total = parentTasks.length;
+
+    // Ensure the dex label exists
+    await this.api.ensureLabel(this.label);
+
+    // Fetch all stories once at start for efficient lookups
+    const storyCache = await this.fetchAllDexStories();
+
+    for (let i = 0; i < parentTasks.length; i++) {
+      const parent = parentTasks[i];
+
+      // Report checking phase
+      onProgress?.({
+        current: i + 1,
+        total,
+        task: parent,
+        phase: "checking",
+      });
+
+      const result = await this.syncParentTask(parent, store, {
+        skipUnchanged,
+        onProgress,
+        currentIndex: i + 1,
+        total,
+        storyCache,
+      });
+      if (result) {
+        results.push(result);
+      }
+    }
+    return results;
+  }
+
+  /**
+   * Build a SyncResult for an existing story.
+   */
+  private buildSyncResult(
+    taskId: string,
+    storyId: number,
+    storyUrl: string,
+    created: boolean,
+    state: "unstarted" | "started" | "done",
+    skipped?: boolean,
+  ): SyncResult {
+    return {
+      taskId,
+      shortcut: {
+        storyId,
+        storyUrl,
+        workspace: this.workspace,
+        state,
+      },
+      created,
+      skipped,
+    };
+  }
+
+  /**
+   * Sync a parent task (with all descendants) to Shortcut.
+   * Returns sync result with shortcut metadata.
+   */
+  private async syncParentTask(
+    parent: Task,
+    store: TaskStore,
+    options: {
+      skipUnchanged?: boolean;
+      onProgress?: (progress: SyncProgress) => void;
+      currentIndex?: number;
+      total?: number;
+      storyCache?: Map<string, CachedStory>;
+    } = {},
+  ): Promise<SyncResult | null> {
+    const {
+      skipUnchanged = true,
+      onProgress,
+      currentIndex = 1,
+      total = 1,
+      storyCache,
+    } = options;
+
+    // Collect subtasks (immediate children only - they become sub-stories)
+    const subtasks = store.tasks.filter((t) => t.parent_id === parent.id);
+
+    // Check for existing story: first metadata, then cache, then API fallback
+    let storyId = getShortcutStoryId(parent);
+    if (!storyId && storyCache) {
+      const cached = storyCache.get(parent.id);
+      if (cached) {
+        storyId = cached.id;
+      }
+    }
+    if (!storyId) {
+      // Fallback for single-task sync (no cache)
+      storyId = await this.findStoryByTaskId(parent.id);
+    }
+
+    const workflowId = await this.getWorkflowId();
+    const expectedStateType = parent.completed ? "done" : "unstarted";
+
+    if (storyId) {
+      // Fast path: skip completed tasks that are already synced as done
+      const storedState = parent.metadata?.shortcut?.state;
+      if (
+        skipUnchanged &&
+        expectedStateType === "done" &&
+        storedState === "done"
+      ) {
+        onProgress?.({
+          current: currentIndex,
+          total,
+          task: parent,
+          phase: "skipped",
+        });
+        const storyUrl = await this.api.buildStoryUrl(storyId);
+        return this.buildSyncResult(
+          parent.id,
+          storyId,
+          storyUrl,
+          false,
+          expectedStateType,
+          true,
+        );
+      }
+
+      // Check if we can skip this update by comparing with Shortcut
+      if (skipUnchanged) {
+        const expectedDescription = renderStoryDescription(parent);
+
+        // Use cached data for change detection when available
+        const cached = storyCache?.get(parent.id);
+        const hasChanges = cached
+          ? this.hasStoryChangedFromCache(
+              cached,
+              parent.name,
+              expectedDescription,
+              parent.completed,
+            )
+          : await this.hasStoryChanged(
+              storyId,
+              parent.name,
+              expectedDescription,
+              parent.completed,
+            );
+
+        if (!hasChanges) {
+          onProgress?.({
+            current: currentIndex,
+            total,
+            task: parent,
+            phase: "skipped",
+          });
+          const storyUrl = await this.api.buildStoryUrl(storyId);
+          return this.buildSyncResult(
+            parent.id,
+            storyId,
+            storyUrl,
+            false,
+            expectedStateType,
+            true,
+          );
+        }
+      }
+
+      onProgress?.({
+        current: currentIndex,
+        total,
+        task: parent,
+        phase: "updating",
+      });
+
+      await this.updateStory(parent, storyId, workflowId);
+
+      // Sync subtasks as sub-stories
+      await this.syncSubtasks(subtasks, storyId, store, workflowId);
+
+      const storyUrl = await this.api.buildStoryUrl(storyId);
+      return this.buildSyncResult(
+        parent.id,
+        storyId,
+        storyUrl,
+        false,
+        expectedStateType,
+      );
+    } else {
+      onProgress?.({
+        current: currentIndex,
+        total,
+        task: parent,
+        phase: "creating",
+      });
+
+      const shortcut = await this.createStory(parent, workflowId);
+
+      // Sync subtasks as sub-stories
+      await this.syncSubtasks(subtasks, shortcut.storyId, store, workflowId);
+
+      return { taskId: parent.id, shortcut, created: true };
+    }
+  }
+
+  /**
+   * Sync subtasks as sub-stories.
+   */
+  private async syncSubtasks(
+    subtasks: Task[],
+    parentStoryId: number,
+    store: TaskStore,
+    workflowId: number,
+  ): Promise<void> {
+    for (const subtask of subtasks) {
+      let subStoryId = getShortcutStoryId(subtask);
+
+      if (subStoryId) {
+        // Update existing sub-story
+        await this.updateStory(subtask, subStoryId, workflowId);
+      } else {
+        // Create new sub-story
+        const description = renderStoryDescription(subtask);
+        const stateId = await this.getWorkflowStateId(subtask, workflowId);
+
+        const story = await this.api.createSubStory(parentStoryId, {
+          name: subtask.name,
+          description,
+          story_type: "chore",
+          workflow_state_id: stateId,
+          labels: [{ name: this.label }],
+        });
+
+        // Note: The subtask's metadata will be updated by the caller
+        subStoryId = story.id;
+      }
+
+      // Recursively sync nested subtasks
+      const nestedSubtasks = store.tasks.filter(
+        (t) => t.parent_id === subtask.id,
+      );
+      if (nestedSubtasks.length > 0) {
+        await this.syncSubtasks(nestedSubtasks, subStoryId, store, workflowId);
+      }
+    }
+  }
+
+  /**
+   * Check if a story has changed compared to what we would push.
+   * Returns true if the story needs updating.
+   */
+  private async hasStoryChanged(
+    storyId: number,
+    expectedName: string,
+    expectedDescription: string,
+    shouldBeCompleted: boolean,
+  ): Promise<boolean> {
+    try {
+      const story = await this.api.getStory(storyId);
+      return this.storyNeedsUpdate(
+        {
+          name: story.name,
+          description: story.description,
+          completed: story.completed,
+          labels: story.labels.map((l) => l.name),
+        },
+        expectedName,
+        expectedDescription,
+        shouldBeCompleted,
+      );
+    } catch {
+      // If we can't fetch the story, assume it needs updating
+      return true;
+    }
+  }
+
+  /**
+   * Check if a story has changed using cached data.
+   */
+  private hasStoryChangedFromCache(
+    cached: CachedStory,
+    expectedName: string,
+    expectedDescription: string,
+    shouldBeCompleted: boolean,
+  ): boolean {
+    return this.storyNeedsUpdate(
+      {
+        name: cached.name,
+        description: cached.description,
+        completed: cached.completed,
+        labels: cached.labels,
+      },
+      expectedName,
+      expectedDescription,
+      shouldBeCompleted,
+    );
+  }
+
+  /**
+   * Compare story data against expected values.
+   * Returns true if any field differs (story needs updating).
+   */
+  private storyNeedsUpdate(
+    story: {
+      name: string;
+      description: string;
+      completed: boolean;
+      labels: string[];
+    },
+    expectedName: string,
+    expectedDescription: string,
+    shouldBeCompleted: boolean,
+  ): boolean {
+    if (story.name !== expectedName) return true;
+    if (story.description.trim() !== expectedDescription.trim()) return true;
+    if (story.completed !== shouldBeCompleted) return true;
+    if (!story.labels.includes(this.label)) return true;
+    return false;
+  }
+
+  /**
+   * Create a new Shortcut story for a task.
+   * Returns the shortcut metadata for the created story.
+   */
+  private async createStory(
+    task: Task,
+    workflowId: number,
+  ): Promise<ShortcutMetadata> {
+    const teamId = await this.resolveTeamId();
+    const description = renderStoryDescription(task);
+    const stateId = await this.getWorkflowStateId(task, workflowId);
+
+    const story = await this.api.createStory({
+      name: task.name,
+      description,
+      story_type: "feature",
+      workflow_state_id: stateId,
+      labels: [{ name: this.label }],
+      group_id: teamId,
+    });
+
+    const storyUrl = await this.api.buildStoryUrl(story.id);
+    const stateType = await this.getWorkflowStateType(workflowId, stateId);
+
+    return {
+      storyId: story.id,
+      storyUrl,
+      workspace: this.workspace,
+      state: stateType,
+    };
+  }
+
+  /**
+   * Update an existing Shortcut story.
+   */
+  private async updateStory(
+    task: Task,
+    storyId: number,
+    workflowId: number,
+  ): Promise<void> {
+    const description = renderStoryDescription(task);
+    const stateId = await this.getWorkflowStateId(task, workflowId);
+
+    await this.api.updateStory(storyId, {
+      name: task.name,
+      description,
+      workflow_state_id: stateId,
+      labels: [{ name: this.label }],
+    });
+  }
+
+  /**
+   * Look up a task by its local ID in Shortcut stories.
+   * Uses search to find stories with the dex task ID in the description.
+   */
+  async findStoryByTaskId(taskId: string): Promise<number | null> {
+    try {
+      // Search for stories with the dex label that contain the task ID
+      const response = await this.api.searchStories(
+        `label:"${this.label}" description:"dex:task:id:${taskId}"`,
+      );
+
+      for (const story of response.data) {
+        const description = story.description ?? "";
+        const metadata = parseTaskMetadata(description);
+        if (metadata?.id === taskId) {
+          return story.id;
+        }
+      }
+      return null;
+    } catch {
+      return null;
+    }
+  }
+
+  /**
+   * Fetch all dex-labeled stories.
+   * Returns a Map keyed by task ID containing all data needed for change detection.
+   */
+  async fetchAllDexStories(): Promise<Map<string, CachedStory>> {
+    const result = new Map<string, CachedStory>();
+
+    try {
+      const response = await this.api.searchStories(`label:"${this.label}"`);
+
+      for (const story of response.data) {
+        const description = story.description ?? "";
+        const metadata = parseTaskMetadata(description);
+        if (metadata?.id) {
+          result.set(metadata.id, {
+            id: story.id,
+            name: story.name,
+            description,
+            completed: story.completed,
+            labels: story.labels.map((l) => l.name),
+          });
+        }
+      }
+    } catch {
+      // Return empty map on error
+    }
+
+    return result;
+  }
+}
+
+/**
+ * Extract Shortcut story ID from task metadata.
+ * Returns null if not synced yet.
+ */
+export function getShortcutStoryId(task: Task): number | null {
+  if (task.metadata?.shortcut?.storyId) {
+    return task.metadata.shortcut.storyId;
+  }
+  return null;
+}

--- a/src/core/shortcut/token.ts
+++ b/src/core/shortcut/token.ts
@@ -1,0 +1,15 @@
+/**
+ * Get Shortcut API token from environment variable.
+ * @param tokenEnv Environment variable name to check (default: SHORTCUT_API_TOKEN)
+ * @returns Token string or null if not found
+ */
+export function getShortcutToken(
+  tokenEnv: string = "SHORTCUT_API_TOKEN",
+): string | null {
+  const envToken = process.env[tokenEnv];
+  if (envToken) {
+    return envToken;
+  }
+
+  return null;
+}

--- a/src/test-utils/shortcut-mock.ts
+++ b/src/test-utils/shortcut-mock.ts
@@ -1,0 +1,255 @@
+/**
+ * Shared Shortcut API mocking utilities for tests.
+ * Used by both CLI and core module tests.
+ */
+
+import nock from "nock";
+
+// ============ Shortcut API Mocking ============
+
+export interface ShortcutStoryFixture {
+  id: number;
+  name: string;
+  description?: string;
+  completed: boolean;
+  app_url: string;
+  labels: Array<{ name: string }>;
+  workflow_state_id?: number;
+}
+
+export interface ShortcutWorkflowFixture {
+  id: number;
+  name: string;
+  states: Array<{
+    id: number;
+    name: string;
+    type: "unstarted" | "started" | "done";
+  }>;
+}
+
+export interface ShortcutTeamFixture {
+  id: string;
+  name: string;
+  mention_name: string;
+  workflow_ids: number[];
+}
+
+export interface ShortcutMemberFixture {
+  id: string;
+  profile: { name: string };
+  workspace2: { url_slug: string };
+}
+
+export interface ShortcutMock {
+  scope: nock.Scope;
+  getCurrentMember: (response: ShortcutMemberFixture) => void;
+  getStory: (storyId: number, response: ShortcutStoryFixture) => void;
+  getStory404: (storyId: number) => void;
+  getStory401: (storyId: number) => void;
+  getStory500: (storyId: number) => void;
+  searchStories: (response: ShortcutStoryFixture[]) => void;
+  searchStories401: () => void;
+  searchStories500: () => void;
+  createStory: (response: ShortcutStoryFixture) => void;
+  createStory401: () => void;
+  createStory500: () => void;
+  updateStory: (storyId: number, response: ShortcutStoryFixture) => void;
+  updateStory401: (storyId: number) => void;
+  updateStory500: (storyId: number) => void;
+  getWorkflow: (workflowId: number, response: ShortcutWorkflowFixture) => void;
+  listWorkflows: (response: ShortcutWorkflowFixture[]) => void;
+  getGroup: (groupId: string, response: ShortcutTeamFixture) => void;
+  listGroups: (response: ShortcutTeamFixture[]) => void;
+  listLabels: (response: Array<{ id: number; name: string }>) => void;
+  createLabel: (response: { id: number; name: string }) => void;
+  done: () => void;
+}
+
+/**
+ * Set up nock interceptors for Shortcut API.
+ * Call mock.done() in afterEach to verify all expected requests were made.
+ */
+export function setupShortcutMock(): ShortcutMock {
+  const scope = nock("https://api.app.shortcut.com");
+
+  return {
+    scope,
+
+    getCurrentMember(response: ShortcutMemberFixture) {
+      scope.get("/api/v3/member").reply(200, response);
+    },
+
+    getStory(storyId: number, response: ShortcutStoryFixture) {
+      scope.get(`/api/v3/stories/${storyId}`).reply(200, response);
+    },
+
+    getStory404(storyId: number) {
+      scope
+        .get(`/api/v3/stories/${storyId}`)
+        .reply(404, { message: "Resource not found" });
+    },
+
+    getStory401(storyId: number) {
+      scope
+        .get(`/api/v3/stories/${storyId}`)
+        .reply(401, { message: "Unauthorized" });
+    },
+
+    getStory500(storyId: number) {
+      scope
+        .get(`/api/v3/stories/${storyId}`)
+        .reply(500, { message: "Internal Server Error" });
+    },
+
+    searchStories(response: ShortcutStoryFixture[]) {
+      scope.get("/api/v3/search/stories").query(true).reply(200, {
+        data: response,
+        next: null,
+        total: response.length,
+      });
+    },
+
+    searchStories401() {
+      scope
+        .get("/api/v3/search/stories")
+        .query(true)
+        .reply(401, { message: "Unauthorized" });
+    },
+
+    searchStories500() {
+      scope
+        .get("/api/v3/search/stories")
+        .query(true)
+        .reply(500, { message: "Internal Server Error" });
+    },
+
+    createStory(response: ShortcutStoryFixture) {
+      scope.post("/api/v3/stories").reply(201, response);
+    },
+
+    createStory401() {
+      scope.post("/api/v3/stories").reply(401, { message: "Unauthorized" });
+    },
+
+    createStory500() {
+      scope
+        .post("/api/v3/stories")
+        .reply(500, { message: "Internal Server Error" });
+    },
+
+    updateStory(storyId: number, response: ShortcutStoryFixture) {
+      scope.put(`/api/v3/stories/${storyId}`).reply(200, response);
+    },
+
+    updateStory401(storyId: number) {
+      scope
+        .put(`/api/v3/stories/${storyId}`)
+        .reply(401, { message: "Unauthorized" });
+    },
+
+    updateStory500(storyId: number) {
+      scope
+        .put(`/api/v3/stories/${storyId}`)
+        .reply(500, { message: "Internal Server Error" });
+    },
+
+    getWorkflow(workflowId: number, response: ShortcutWorkflowFixture) {
+      scope.get(`/api/v3/workflows/${workflowId}`).reply(200, response);
+    },
+
+    listWorkflows(response: ShortcutWorkflowFixture[]) {
+      scope.get("/api/v3/workflows").reply(200, response);
+    },
+
+    getGroup(groupId: string, response: ShortcutTeamFixture) {
+      scope.get(`/api/v3/groups/${groupId}`).reply(200, response);
+    },
+
+    listGroups(response: ShortcutTeamFixture[]) {
+      scope.get("/api/v3/groups").reply(200, response);
+    },
+
+    listLabels(response: Array<{ id: number; name: string }>) {
+      scope.get("/api/v3/labels").reply(200, response);
+    },
+
+    createLabel(response: { id: number; name: string }) {
+      scope.post("/api/v3/labels").reply(201, response);
+    },
+
+    done() {
+      scope.done();
+    },
+  };
+}
+
+/**
+ * Clean up all nock interceptors for Shortcut.
+ * Call in afterEach to reset state between tests.
+ */
+export function cleanupShortcutMock(): void {
+  nock.cleanAll();
+}
+
+/**
+ * Create a minimal Shortcut story fixture.
+ */
+export function createStoryFixture(
+  overrides: Partial<ShortcutStoryFixture> & { id: number },
+): ShortcutStoryFixture {
+  return {
+    name: `Test Story #${overrides.id}`,
+    description: "",
+    completed: false,
+    app_url: `https://app.shortcut.com/test-workspace/story/${overrides.id}`,
+    labels: [],
+    workflow_state_id: 500000001,
+    ...overrides,
+  };
+}
+
+/**
+ * Create a minimal Shortcut workflow fixture.
+ */
+export function createWorkflowFixture(
+  overrides: Partial<ShortcutWorkflowFixture> & { id: number },
+): ShortcutWorkflowFixture {
+  return {
+    name: "Development",
+    states: [
+      { id: 500000001, name: "Unstarted", type: "unstarted" },
+      { id: 500000002, name: "In Progress", type: "started" },
+      { id: 500000003, name: "Done", type: "done" },
+    ],
+    ...overrides,
+  };
+}
+
+/**
+ * Create a minimal Shortcut team fixture.
+ */
+export function createTeamFixture(
+  overrides: Partial<ShortcutTeamFixture> = {},
+): ShortcutTeamFixture {
+  return {
+    id: "test-team-uuid",
+    name: "Test Team",
+    mention_name: "test-team",
+    workflow_ids: [500000000],
+    ...overrides,
+  };
+}
+
+/**
+ * Create a minimal Shortcut member fixture.
+ */
+export function createMemberFixture(
+  overrides: Partial<ShortcutMemberFixture> = {},
+): ShortcutMemberFixture {
+  return {
+    id: "test-member-uuid",
+    profile: { name: "Test User" },
+    workspace2: { url_slug: "test-workspace" },
+    ...overrides,
+  };
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -22,10 +22,20 @@ export const GithubMetadataSchema = z.object({
 
 export type GithubMetadata = z.infer<typeof GithubMetadataSchema>;
 
+export const ShortcutMetadataSchema = z.object({
+  storyId: z.number().int().positive(),
+  storyUrl: z.string().url(),
+  workspace: z.string().min(1),
+  state: z.enum(["unstarted", "started", "done"]).optional(), // Last synced workflow state
+});
+
+export type ShortcutMetadata = z.infer<typeof ShortcutMetadataSchema>;
+
 export const TaskMetadataSchema = z
   .object({
     commit: CommitMetadataSchema.optional(),
     github: GithubMetadataSchema.optional(),
+    shortcut: ShortcutMetadataSchema.optional(),
   })
   .nullable();
 
@@ -205,6 +215,7 @@ export const ArchivedTaskSchema = z.object({
   metadata: z
     .object({
       github: GithubMetadataSchema.optional(),
+      shortcut: ShortcutMetadataSchema.optional(),
       commit: CommitMetadataSchema.optional(),
     })
     .nullable()


### PR DESCRIPTION
## Summary

- Add support for syncing dex tasks to Shortcut Stories, mirroring the existing GitHub Issues integration
- Add `dex sync --shortcut` and `dex import sc#N` commands
- Subtasks sync as linked sub-stories in Shortcut

## Changes

- Add `ShortcutSyncService` with create/update story support
- Add `ShortcutApi` client wrapping `@shortcut/client`
- Add `ShortcutMetadata` type for task metadata persistence
- Add `ShortcutSyncConfig` for dex.toml configuration
- Update CLI help and documentation

## Test plan

- [x] All 743 tests passing
- [x] Added 5 new Shortcut sync tests for parity with GitHub tests
- [x] Added metadata persistence verification test
- [x] Added test utilities for Shortcut API mocking

🤖 Generated with [Claude Code](https://claude.ai/code)