### PR TITLE
fix(cli): Return updated task with GitHub metadata after create

### DIFF
--- a/src/core/task-service.ts
+++ b/src/core/task-service.ts
@@ -340,7 +340,11 @@ export class TaskService {
     // Sync to GitHub if enabled
     await this.syncToIntegrations(task);
 
-    return task;
+    // Re-fetch task to get any metadata added by integrations
+    const updatedStore = await this.storage.readAsync();
+    const updatedTask = updatedStore.tasks.find((t) => t.id === task.id);
+
+    return updatedTask ?? task;
   }
 
   async update(input: UpdateTaskInput): Promise<Task> {


### PR DESCRIPTION
Show GitHub issue info immediately after `dex add` creates a task.

Previously, `dex add` would create a task and sync it to GitHub, but the CLI
output wouldn't show the GitHub issue information (number, repo, URL). Users
had to run `dex show` to see it.

The root cause was that `TaskService.create()` returned the original task
object, but `syncToIntegrations()` writes the GitHub metadata to storage
without updating the in-memory object. The fix re-fetches the task from
storage after sync completes, ensuring any integration metadata is included
in the returned task.