### PR TITLE
feat(sync): Close remote issues when deleting synced tasks

### DIFF
--- a/src/core/github/sync.ts
+++ b/src/core/github/sync.ts
@@ -143,6 +143,22 @@ export class GitHubSyncService {
   }
 
   /**
+   * Close the GitHub issue for a task (e.g., when the task is deleted locally).
+   * If the task has no associated issue, this is a no-op.
+   */
+  async closeRemote(task: Task): Promise<void> {
+    const issueNumber = this.getRemoteId(task);
+    if (!issueNumber) return;
+
+    await this.octokit.issues.update({
+      owner: this.owner,
+      repo: this.repo,
+      issue_number: issueNumber,
+      state: "closed",
+    });
+  }
+
+  /**
    * Sync a single task to GitHub.
    * For subtasks, syncs the parent issue instead.
    * Returns sync result with github metadata.

--- a/src/core/sync/registry.ts
+++ b/src/core/sync/registry.ts
@@ -26,6 +26,11 @@ export interface RegisterableSyncService {
     store: TaskStore,
     options?: SyncAllOptions,
   ): Promise<LegacySyncResult[]>;
+  /**
+   * Close the remote item for a task (e.g., when the task is deleted locally).
+   * Optional - services that don't support this will be skipped.
+   */
+  closeRemote?(task: Task): Promise<void>;
 }
 
 /**

--- a/src/core/task-service.ts
+++ b/src/core/task-service.ts
@@ -476,6 +476,7 @@ export class TaskService {
 
   /**
    * Delete a task and all its descendants.
+   * Closes any associated remote issues (e.g., GitHub issues) before deleting.
    * @param id The task ID to delete
    * @returns The deleted task
    * @throws NotFoundError if the task does not exist
@@ -494,6 +495,9 @@ export class TaskService {
     const toDelete = new Set<string>([id]);
     collectDescendantIds(store.tasks, id, toDelete);
 
+    // Close remote issues for all tasks being deleted
+    await this.closeRemoteIssues(store, toDelete);
+
     // Clean up references to all deleted tasks
     for (const taskId of toDelete) {
       cleanupTaskReferences(store, taskId);
@@ -502,6 +506,40 @@ export class TaskService {
     store.tasks = store.tasks.filter((t) => !toDelete.has(t.id));
     await this.storage.writeAsync(store);
     return deletedTask;
+  }
+
+  /**
+   * Close remote issues for a set of tasks being deleted.
+   * Errors are caught and logged but don't fail the delete operation.
+   */
+  private async closeRemoteIssues(
+    store: TaskStore,
+    taskIds: Set<string>,
+  ): Promise<void> {
+    if (!this.syncRegistry?.hasServices()) return;
+
+    const services = this.syncRegistry
+      .getAll()
+      .filter((s) => s.closeRemote !== undefined);
+    if (services.length === 0) return;
+
+    const tasksToClose = store.tasks.filter((t) => taskIds.has(t.id));
+
+    // Close all issues in parallel - each task/service combination is independent
+    const closeOperations = tasksToClose.flatMap((task) =>
+      services.map(async (service) => {
+        try {
+          await service.closeRemote!(task);
+        } catch (err) {
+          console.warn(
+            `Failed to close ${service.displayName} issue for task ${task.id}:`,
+            err instanceof Error ? err.message : err,
+          );
+        }
+      }),
+    );
+
+    await Promise.all(closeOperations);
   }
 
   async getChildren(id: string): Promise<Task[]> {


### PR DESCRIPTION
When running `dex remove` on a task synced to GitHub, the corresponding
GitHub issue is now automatically closed. This maintains consistency with
how create/update operations sync to remote integrations.

Previously, deleting a synced task would only remove it locally, leaving
the GitHub issue orphaned and open. Now the local storage remains the
source of truth and deletions propagate to the remote.

Changes:
- Add optional `closeRemote` method to `RegisterableSyncService` interface
- Implement `closeRemote` in `GitHubSyncService`
- Update `TaskService.delete` to close remote issues before local deletion
- Close operations run in parallel; errors are logged but don't block deletion