### PR TITLE
fix(cli): Fail if `dex create` get more than one positional argument

### DIFF
--- a/src/cli/create.test.ts
+++ b/src/cli/create.test.ts
@@ -162,4 +162,24 @@ describe("create command", () => {
     expect(task.created_at).toBeTruthy();
     expect(task.updated_at).toBeTruthy();
   });
+
+  it("fails when multiple positional arguments are provided", async () => {
+    await expect(
+      runCli(
+        [
+          "create",
+          "Task name",
+          "This looks like a description but is a second positional arg",
+        ],
+        { storage: fixture.storage },
+      ),
+    ).rejects.toThrow("process.exit");
+
+    expect(fixture.output.stderr.join("\n")).toContain(
+      "unexpected positional argument",
+    );
+
+    const tasks = await fixture.storage.readAsync();
+    expect(tasks.tasks).toHaveLength(0);
+  });
 });

--- a/src/cli/create.ts
+++ b/src/cli/create.ts
@@ -55,6 +55,16 @@ ${colors.bold}EXAMPLES:${colors.reset}
   const name = positional[0] || getStringFlag(flags, "name");
   const description = getStringFlag(flags, "description");
 
+  // Error if extra positional arguments are provided
+  if (positional.length > 1) {
+    console.error(
+      `${colors.red}Error:${colors.reset} unexpected positional argument: "${positional[1]}"`,
+    );
+    console.error(`Usage: dex create "task name" [--description "details"]`);
+    console.error(`Hint: Use --description or -d to provide a description`);
+    process.exit(1);
+  }
+
   if (!name) {
     console.error(`${colors.red}Error:${colors.reset} name is required`);
     console.error(`Usage: dex create "task name" [--description "details"]`);


### PR DESCRIPTION
Up to this change, `dex create` was using the first positional argument as the name and was ignoring the rest. That might be surprising if people forget to pass `--description` and just add description as the second positional argument, like:
```
$ dex create "Task name" "Ignored task description"
```

With this change, `dex create` will fail in this case with a hint of suggestion usage of `--description` to pass the description properly.

---

Pi session: https://buildwithpi.ai/session/#bd6de1687a2313af515816d1f756ded1