### PR TITLE
feat(edit): Add `--unstart` flag to clear started status

### DIFF
--- a/docs/src/pages/cli.astro
+++ b/docs/src/pages/cli.astro
@@ -163,12 +163,14 @@ dex complete abc123 --result "Planning complete, no code changes" --no-commit`}
       <li><code>-d, --description</code> — Updated description</li>
       <li><code>--add-blocker &lt;id&gt;</code> — Add blocking dependency</li>
       <li><code>--remove-blocker &lt;id&gt;</code> — Remove blocking dependency</li>
+      <li><code>--unstart</code> — Clear started status (move back to ready)</li>
     </ul>
     <Terminal title="Terminal">
       <Code
         code={`dex edit abc123 -n "Updated name"
 dex edit abc123 --add-blocker xyz789
-dex edit abc123 --remove-blocker xyz789`}
+dex edit abc123 --remove-blocker xyz789
+dex edit abc123 --unstart`}
         lang="bash"
         theme="vitesse-black"
       />

--- a/src/cli/edit.test.ts
+++ b/src/cli/edit.test.ts
@@ -370,4 +370,39 @@ describe("edit command", () => {
     const out = output.stdout.join("\n");
     expect(out).toContain("--commit");
   });
+
+  it("moves an in-progress task back to ready with --unstart", async () => {
+    await runCli(["create", "-n", "In progress task", "--description", "ctx"], {
+      storage,
+    });
+    const taskId = output.stdout.join("\n").match(TASK_ID_REGEX)?.[1];
+    output.stdout.length = 0;
+
+    // Start the task
+    await runCli(["start", taskId!], { storage });
+    output.stdout.length = 0;
+
+    // Verify it's in progress
+    const storeBeforeUnstart = await storage.readAsync();
+    const taskBefore = storeBeforeUnstart.tasks.find((t) => t.id === taskId);
+    expect(taskBefore?.started_at).toBeTruthy();
+
+    // Unstart the task
+    await runCli(["edit", taskId!, "--unstart"], { storage });
+
+    const out = output.stdout.join("\n");
+    expect(out).toContain("Updated");
+
+    // Verify started_at is cleared
+    const storeAfter = await storage.readAsync();
+    const taskAfter = storeAfter.tasks.find((t) => t.id === taskId);
+    expect(taskAfter?.started_at).toBeNull();
+  });
+
+  it("shows --unstart in help", async () => {
+    await runCli(["edit", "-h"], { storage });
+
+    const out = output.stdout.join("\n");
+    expect(out).toContain("--unstart");
+  });
 });

--- a/src/cli/edit.ts
+++ b/src/cli/edit.ts
@@ -24,6 +24,7 @@ export async function editCommand(
       "add-blocker": { hasValue: true },
       "remove-blocker": { hasValue: true },
       commit: { short: "c", hasValue: true },
+      unstart: { hasValue: false },
       help: { short: "h", hasValue: false },
     },
     "edit",
@@ -46,6 +47,7 @@ ${colors.bold}OPTIONS:${colors.reset}
   --add-blocker <ids>        Comma-separated task IDs to add as blockers
   --remove-blocker <ids>     Comma-separated task IDs to remove as blockers
   -c, --commit <sha>         Link a git commit to the task
+  --unstart                  Clear started status (move back to ready)
   -h, --help                 Show this help message
 
 ${colors.bold}EXAMPLE:${colors.reset}
@@ -55,6 +57,7 @@ ${colors.bold}EXAMPLE:${colors.reset}
   dex edit abc123 --add-blocker def456
   dex edit abc123 --remove-blocker def456
   dex edit abc123 --commit a1b2c3d
+  dex edit abc123 --unstart
 `);
     return;
   }
@@ -118,6 +121,8 @@ ${colors.bold}EXAMPLE:${colors.reset}
       };
     }
 
+    const unstart = getBooleanFlag(flags, "unstart");
+
     const task = await service.update({
       id,
       name: getStringFlag(flags, "name"),
@@ -127,6 +132,7 @@ ${colors.bold}EXAMPLE:${colors.reset}
       add_blocked_by: addBlockedBy,
       remove_blocked_by: removeBlockedBy,
       metadata,
+      ...(unstart ? { started_at: null } : {}),
     });
 
     console.log(

--- a/src/cli/help.ts
+++ b/src/cli/help.ts
@@ -30,6 +30,7 @@ ${colors.bold}COMMANDS:${colors.reset}
   show <id> --json                 Output as JSON (for scripts)
   edit <id> [-n "..."]             Edit task
   edit <id> --commit <sha>         Link commit to completed task
+  edit <id> --unstart              Move task from in progress back to ready
   update                           Alias for edit command
   start <id>                       Mark task as in progress
   start <id> --force               Re-claim task already in progress


### PR DESCRIPTION
This is useful to move a in-progress task back to ready-to-work status.

Alternative way do to is to edit JSONL files directly, but having an option on `dex edit` seems cleaner.

I do have a agent loop that picks ready-to-work Dex tasks and work on them until completion, but I also do have a check to see if the agent stuck on a task for some period of time, and if so, I do `git reset` to reset everything and start the work from strach. `git reset` does the trick if you track `.dex/` in your Git repository, but if you use global directory or if you don't track `.dex/` in your repository, this command would be useful to reset Dex state.

Pi session: https://pi.dev/session/#3bbd100f2ad00a5e98990e8e1b84841c